### PR TITLE
fix: resolve AI copywriter, rationalizer, and CMS bugs across the site

### DIFF
--- a/app/admin/content/page.tsx
+++ b/app/admin/content/page.tsx
@@ -95,6 +95,16 @@ const SECTION_SCHEMA: Record<string, { key: string; label: string; type: "text" 
     ],
 }
 
+// Template shapes for object_list fields so "Add Item" on empty lists creates usable fields
+const OBJECT_LIST_TEMPLATES: Record<string, Record<string, any>> = {
+    "promo_banner.items": { text: "", link: "" },
+    "trust_badges.items": { text: "", icon: "" },
+    "trust_banner.items": { text: "", icon: "" },
+    "trust_story.points": { title: "", description: "" },
+    "testimonials.items": { name: "", text: "", rating: 5 },
+    "about.values": { title: "", description: "" },
+}
+
 export default function ContentEditorPage() {
     const [activeSection, setActiveSection] = useState("hero")
     const [content, setContent] = useState<Record<string, Record<string, any>>>({})
@@ -296,6 +306,7 @@ export default function ContentEditorPage() {
                             <FieldEditor
                                 key={field.key}
                                 field={field}
+                                section={activeSection}
                                 value={editState[activeSection]?.[field.key]}
                                 onChange={(val) => updateField(activeSection, field.key, val)}
                             />
@@ -318,10 +329,12 @@ export default function ContentEditorPage() {
 // Field Editor component
 function FieldEditor({
     field,
+    section,
     value,
     onChange,
 }: {
     field: { key: string; label: string; type: string }
+    section: string
     value: any
     onChange: (val: any) => void
 }) {
@@ -462,7 +475,11 @@ function FieldEditor({
                         <Button
                             variant="outline"
                             size="sm"
-                            onClick={() => onChange([{}])}
+                            onClick={() => {
+                                const templateKey = `${section}.${field.key}`
+                                const template = OBJECT_LIST_TEMPLATES[templateKey] || {}
+                                onChange([{ ...template }])
+                            }}
                             className="gap-1"
                         >
                             <Plus className="h-3 w-3" />

--- a/app/api/admin/content/route.ts
+++ b/app/api/admin/content/route.ts
@@ -75,7 +75,8 @@ export async function PUT(request: Request) {
         }
 
         invalidateContentCache(section)
-        revalidatePath("/")
+        revalidatePath("/", "layout")
+        revalidatePath("/shop")
         revalidatePath("/about")
         revalidatePath("/faq")
 

--- a/app/api/admin/generate-copy/route.ts
+++ b/app/api/admin/generate-copy/route.ts
@@ -222,8 +222,8 @@ export async function GET(request: Request) {
                     currentCopy: {
                         description: product.description || "",
                         longDescription: metadata.longDescription || "",
-                        features: metadata.features ? JSON.parse(metadata.features) : [],
-                        sellingPoints: metadata.sellingPoints ? JSON.parse(metadata.sellingPoints) : [],
+                        features: (() => { try { return metadata.features ? JSON.parse(metadata.features) : [] } catch { return [] } })(),
+                        sellingPoints: (() => { try { return metadata.sellingPoints ? JSON.parse(metadata.sellingPoints) : [] } catch { return [] } })(),
                         variant: metadata.copyVariant || null,
                         generatedAt: metadata.copyGeneratedAt || null,
                     },

--- a/app/product/[id]/product-detail-client.tsx
+++ b/app/product/[id]/product-detail-client.tsx
@@ -17,7 +17,7 @@ import { ProductReviews } from "@/components/product-reviews"
 import { WishlistButton } from "@/components/wishlist-button"
 import { Breadcrumbs } from "@/components/breadcrumbs"
 import { TrustBadges } from "@/components/trust-badges"
-import { ShoppingBag, Check, Shield, RotateCcw, Plus, Package, Zap, Award } from "lucide-react"
+import { ShoppingBag, Check, Shield, RotateCcw, Plus, Package, Zap, Award, Sparkles } from "lucide-react"
 import { StickyAddToCart } from "@/components/sticky-add-to-cart"
 import { RecentlyViewed } from "@/components/recently-viewed"
 
@@ -301,6 +301,22 @@ export function ProductDetailClient({ product, relatedProducts }: ProductDetailC
                             <Check className="h-4 w-4 text-green-600" />
                           </div>
                           <span className="text-muted-foreground">{feature}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {product.sellingPoints && product.sellingPoints.length > 0 && (
+                  <div className="mt-8">
+                    <h3 className="text-xl font-bold mb-4">Why Buy This</h3>
+                    <ul className="grid gap-3">
+                      {product.sellingPoints.map((point, index) => (
+                        <li key={index} className="flex items-start gap-3">
+                          <div className="w-6 h-6 rounded-full bg-pop-orange/20 flex items-center justify-center flex-shrink-0 mt-0.5">
+                            <Sparkles className="h-4 w-4 text-pop-orange" />
+                          </div>
+                          <span className="text-muted-foreground">{point}</span>
                         </li>
                       ))}
                     </ul>

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -27,6 +27,7 @@ export interface Product {
     size?: string
   }
   features?: string[]
+  sellingPoints?: string[]
   inStock: boolean
   stockCount?: number
   reviewCount?: number

--- a/lib/stripe-products.ts
+++ b/lib/stripe-products.ts
@@ -44,7 +44,8 @@ function transformStripeProduct(
             material: metadata.material,
             size: metadata.size,
         },
-        features: metadata.features ? JSON.parse(metadata.features) : undefined,
+        features: (() => { try { return metadata.features ? JSON.parse(metadata.features) : undefined } catch { return undefined } })(),
+        sellingPoints: (() => { try { return metadata.sellingPoints ? JSON.parse(metadata.sellingPoints) : undefined } catch { return undefined } })(),
         inStock: product.active && (metadata.inStock !== "false"),
         stockCount: metadata.stockCount
             ? parseInt(metadata.stockCount, 10)


### PR DESCRIPTION
- Complete the sellingPoints pipeline: add to Product type, extract from Stripe metadata, and render on product detail pages
- Fix rationalizer JSON parsing to strip markdown code blocks before extracting JSON (matches existing copywriter behavior)
- Fix rationalizer fallback to generate useful default features and selling points instead of empty arrays, fix description typo
- Add JSON.parse error handling in generate-copy API and stripe-products transform to prevent crashes on malformed metadata
- Fix CMS revalidation to cover all pages (was only revalidating /, /about, /faq — now includes /shop and layout-level revalidation)
- Fix CMS object_list empty-state bug where "Add Item" on empty lists created blank cards with no editable fields

https://claude.ai/code/session_01C1ZqHdKCw16tLNbuJnXmRj