### PR TITLE
fix: AI copywriter, rationalizer, CMS, and categories admin bugs

### DIFF
--- a/lib/product-fallback.ts
+++ b/lib/product-fallback.ts
@@ -10,16 +10,23 @@ const CAMERA_BRANDS = [
     "Canon",
     "Nikon",
     "Fujifilm",
+    "Fuji",
     "Olympus",
     "Kodak",
     "Samsung",
     "Pentax",
     "Casio",
     "Panasonic",
+    "Lumix",
     "HP",
     "Leica",
     "Minolta",
-    "Ricoh"
+    "Ricoh",
+    "Polaroid",
+    "GoPro",
+    "Sanyo",
+    "Kyocera",
+    "Konica"
 ]
 
 export function extractProductInfo(name: string, description: string) {
@@ -30,12 +37,14 @@ export function extractProductInfo(name: string, description: string) {
     }
 
     const lowerName = name.toLowerCase()
-    const lowerDesc = description.toLowerCase()
 
     // 1. Detect Brand
     for (const brand of CAMERA_BRANDS) {
         if (lowerName.includes(brand.toLowerCase())) {
-            info.brand = brand
+            // Normalize aliases
+            if (brand === "Fuji") info.brand = "Fujifilm"
+            else if (brand === "Lumix") info.brand = "Panasonic"
+            else info.brand = brand
             break
         }
     }
@@ -47,7 +56,7 @@ export function extractProductInfo(name: string, description: string) {
     }
 
     // 3. Detect Category (Accessory keywords)
-    const accessoryKeywords = ["battery", "charger", "case", "bag", "strap", "tripod", "cable", "card", "memory"]
+    const accessoryKeywords = ["battery", "charger", "case", "bag", "strap", "tripod", "cable", "card", "memory", "film", "cleaning", "filter", "adapter", "lens cap"]
     if (accessoryKeywords.some(k => lowerName.includes(k))) {
         info.category = "accessory"
     }


### PR DESCRIPTION
## Summary
- **Checkout crash**: added missing `handleComplete` callback that was crashing the checkout page
- **sellingPoints pipeline broken end-to-end**: added to Product type, extracted from Stripe metadata, rendered on product detail pages as "Why Buy This" section
- **Rationalizer silently failing**: Gemini responses wrapped in markdown code blocks caused JSON parse failures, falling back to empty data — likely why 13/24 products stayed "Unknown" brand
- **Rationalizer fallback producing garbage**: empty features/sellingPoints arrays and a typo ("working strategy")
- **JSON.parse crashes**: added try-catch in generate-copy API and stripe-products transform for malformed metadata
- **CMS changes not reflecting**: revalidation only covered 3 pages, now covers all via layout-level revalidation
- **CMS empty object_list bug**: "Add Item" on empty lists created blank cards with no fields — now uses pre-defined templates
- **Brand fallback missing 7 brands**: Polaroid, GoPro, Fuji, Lumix, Sanyo, Kyocera, Konica weren't in the fallback list
- **Categories admin layout overflow**: controls caused infinite horizontal scroll — moved to own row with flex-wrap
- **Categories admin save not working**: local state update wrote to wrong field path so UI didn't reflect changes

## Test plan
- [ ] Checkout page loads and completes purchases without errors
- [ ] Product detail pages show "Why Buy This" selling points section
- [ ] Run "Rationalize All" from admin — products should properly get brand/year/category filled in
- [ ] Edit CMS content → save → changes appear on live site immediately
- [ ] CMS: click "Add Item" on empty object_list → fields appear (not blank)
- [ ] Categories admin: dropdowns and save button don't overflow horizontally
- [ ] Categories admin: change a product's category → click Save → change reflects immediately

https://claude.ai/code/session_01C1ZqHdKCw16tLNbuJnXmRj