### PR TITLE
feat: live inventory tracking with batch quantity ordering

### DIFF
--- a/app/actions/stripe.ts
+++ b/app/actions/stripe.ts
@@ -12,11 +12,21 @@ interface CheckoutItem {
 
 export async function startCheckoutSession(items: CheckoutItem[], userId?: string) {
   // Fetch products from Stripe and build line items (filter out products not found)
+  // Also validates live stock availability to prevent overselling
   const lineItemsPromises = items.map(async (item) => {
     const product = await getStripeProductById(item.productId)
     if (!product) {
       console.warn(`[Checkout] Product ${item.productId} not found in Stripe, skipping`)
       return null
+    }
+    // Stock validation: block checkout if out of stock or requested qty exceeds stockCount
+    if (!product.inStock) {
+      throw new Error(`"${product.name}" is out of stock. Please remove it from your cart.`)
+    }
+    if (typeof product.stockCount === "number" && item.quantity > product.stockCount) {
+      throw new Error(
+        `Only ${product.stockCount} of "${product.name}" available. Please reduce the quantity in your cart.`
+      )
     }
     return {
       price_data: {
@@ -89,10 +99,25 @@ export async function startCheckoutSession(items: CheckoutItem[], userId?: strin
   return session.url
 }
 
-export async function startSingleProductCheckout(productId: string, userId?: string) {
+export async function startSingleProductCheckout(
+  productId: string,
+  userId?: string,
+  quantity: number = 1
+) {
   const product = await getStripeProductById(productId)
   if (!product) {
     throw new Error(`Product with id "${productId}" not found`)
+  }
+
+  // Stock validation
+  if (!product.inStock) {
+    throw new Error(`"${product.name}" is out of stock.`)
+  }
+  const safeQuantity = Math.max(1, Math.floor(quantity))
+  if (typeof product.stockCount === "number" && safeQuantity > product.stockCount) {
+    throw new Error(
+      `Only ${product.stockCount} of "${product.name}" available. Please reduce the quantity.`
+    )
   }
 
   const session = await stripe.checkout.sessions.create({
@@ -109,7 +134,7 @@ export async function startSingleProductCheckout(productId: string, userId?: str
           },
           unit_amount: product.priceInCents,
         },
-        quantity: 1,
+        quantity: safeQuantity,
       },
     ],
     mode: "payment",
@@ -144,7 +169,7 @@ export async function startSingleProductCheckout(productId: string, userId?: str
     },
     metadata: {
       user_id: userId || "",
-      items: `${productId}:1`,
+      items: `${productId}:${safeQuantity}`,
     },
   })
 

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -55,6 +55,18 @@ export async function POST(req: Request) {
 
       const totalInCents = items.reduce((sum, item) => sum + item.priceInCents, 0)
 
+      // Decrement inventory for each purchased product
+      // Uses Stripe product metadata as source of truth for stockCount
+      for (const item of items) {
+        if (item.productId === "unknown") continue
+        try {
+          await decrementProductStock(item.productId, item.quantity)
+        } catch (stockError) {
+          console.error(`[v0] Failed to decrement stock for ${item.productId}:`, stockError)
+          // Don't fail the webhook if stock update fails - order is already paid
+        }
+      }
+
       // Send confirmation email
       if (session.customer_details?.email) {
         try {
@@ -100,4 +112,39 @@ export async function POST(req: Request) {
     console.error("[v0] Webhook error:", error)
     return NextResponse.json({ error: "Webhook handler failed" }, { status: 500 })
   }
+}
+
+// Decrement a product's stockCount in Stripe metadata by the given quantity.
+// Marks the product as out-of-stock (inStock: "false") when count hits 0.
+// If stockCount is not set on the product, this is a no-op (inventory untracked).
+async function decrementProductStock(productId: string, quantity: number) {
+  const product = await stripe.products.retrieve(productId)
+  const currentStockRaw = product.metadata?.stockCount
+
+  // Skip if inventory isn't tracked for this product
+  if (!currentStockRaw) {
+    console.log(`[v0] Product ${productId} has no stockCount metadata - skipping decrement`)
+    return
+  }
+
+  const currentStock = parseInt(currentStockRaw, 10)
+  if (isNaN(currentStock)) {
+    console.warn(`[v0] Invalid stockCount "${currentStockRaw}" for product ${productId}`)
+    return
+  }
+
+  const newStock = Math.max(0, currentStock - quantity)
+
+  const newMetadata: Record<string, string> = {
+    ...product.metadata,
+    stockCount: newStock.toString(),
+  }
+
+  // Auto-mark as out of stock when depleted
+  if (newStock === 0) {
+    newMetadata.inStock = "false"
+  }
+
+  await stripe.products.update(productId, { metadata: newMetadata })
+  console.log(`[v0] Decremented stock for ${productId}: ${currentStock} → ${newStock}`)
 }

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -44,64 +44,74 @@ export default function CartPage() {
         <div className="grid lg:grid-cols-3 gap-8 lg:gap-12">
           {/* Cart items */}
           <div className="lg:col-span-2 space-y-4">
-            {items.map((item) => (
-              <div
-                key={item.product.id}
-                className="flex gap-4 p-4 bg-card rounded-2xl border border-border hover:border-border/80 transition-colors"
-              >
-                {/* Image */}
-                <Link href={`/product/${item.product.id}`} className="shrink-0">
-                  <div className="w-24 h-24 rounded-xl overflow-hidden bg-secondary">
-                    <img
-                      src={item.product.images[0] || "/placeholder.svg"}
-                      alt={item.product.name}
-                      className="w-full h-full object-cover"
-                    />
-                  </div>
-                </Link>
+            {items.map((item) => {
+              const maxStock = typeof item.product.stockCount === "number" ? item.product.stockCount : undefined
+              const atMaxStock = maxStock !== undefined && item.quantity >= maxStock
 
-                {/* Details */}
-                <div className="flex-1 min-w-0">
-                  <Link href={`/product/${item.product.id}`}>
-                    <h3 className="font-medium hover:text-accent transition-colors">{item.product.name}</h3>
+              return (
+                <div
+                  key={item.product.id}
+                  className="flex gap-4 p-4 bg-card rounded-2xl border border-border hover:border-border/80 transition-colors"
+                >
+                  {/* Image */}
+                  <Link href={`/product/${item.product.id}`} className="shrink-0">
+                    <div className="w-24 h-24 rounded-xl overflow-hidden bg-secondary">
+                      <img
+                        src={item.product.images[0] || "/placeholder.svg"}
+                        alt={item.product.name}
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
                   </Link>
-                  <p className="text-sm text-muted-foreground mt-1">{item.product.year}</p>
-                  <p className="font-semibold mt-2">{formatPrice(item.product.priceInCents)}</p>
-                </div>
 
-                {/* Quantity controls */}
-                <div className="flex flex-col items-end justify-between">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 rounded-lg text-muted-foreground hover:text-destructive"
-                    onClick={() => removeItem(item.product.id)}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
+                  {/* Details */}
+                  <div className="flex-1 min-w-0">
+                    <Link href={`/product/${item.product.id}`}>
+                      <h3 className="font-medium hover:text-accent transition-colors">{item.product.name}</h3>
+                    </Link>
+                    <p className="text-sm text-muted-foreground mt-1">{item.product.year}</p>
+                    <p className="font-semibold mt-2">{formatPrice(item.product.priceInCents)}</p>
+                    {atMaxStock && (
+                      <p className="text-xs text-pop-orange mt-1 font-medium">Only {maxStock} in stock</p>
+                    )}
+                  </div>
 
-                  <div className="flex items-center gap-1 bg-secondary rounded-lg p-1">
+                  {/* Quantity controls */}
+                  <div className="flex flex-col items-end justify-between">
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-8 w-8 rounded-md"
-                      onClick={() => updateQuantity(item.product.id, item.quantity - 1)}
+                      className="h-8 w-8 rounded-lg text-muted-foreground hover:text-destructive"
+                      onClick={() => removeItem(item.product.id)}
                     >
-                      <Minus className="h-3 w-3" />
+                      <Trash2 className="h-4 w-4" />
                     </Button>
-                    <span className="w-8 text-center font-mono text-sm">{item.quantity}</span>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 rounded-md"
-                      onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
-                    >
-                      <Plus className="h-3 w-3" />
-                    </Button>
+
+                    <div className="flex items-center gap-1 bg-secondary rounded-lg p-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 rounded-md"
+                        onClick={() => updateQuantity(item.product.id, item.quantity - 1)}
+                      >
+                        <Minus className="h-3 w-3" />
+                      </Button>
+                      <span className="w-8 text-center font-mono text-sm">{item.quantity}</span>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 rounded-md disabled:opacity-40"
+                        onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
+                        disabled={atMaxStock}
+                        aria-label="Increase quantity"
+                      >
+                        <Plus className="h-3 w-3" />
+                      </Button>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
 
           {/* Order summary */}

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -14,6 +14,8 @@ import { Button } from "@/components/ui/button"
 function CheckoutContent() {
   const searchParams = useSearchParams()
   const productId = searchParams.get("product")
+  const qtyParam = searchParams.get("qty")
+  const singleQuantity = Math.max(1, parseInt(qtyParam || "1", 10) || 1)
   const { items, totalPrice } = useCart()
 
   // Fetch single product from API if productId is provided
@@ -99,10 +101,11 @@ function CheckoutContent() {
                       className="w-full h-full object-cover"
                     />
                   </div>
-                  <div>
+                  <div className="flex-1">
                     <p className="font-medium text-sm">{singleProduct.name}</p>
                     <p className="text-sm text-muted-foreground">{singleProduct.year}</p>
-                    <p className="font-bold mt-1">{formatPrice(singleProduct.priceInCents)}</p>
+                    <p className="text-xs text-muted-foreground mt-1">Qty: {singleQuantity}</p>
+                    <p className="font-bold mt-1">{formatPrice(singleProduct.priceInCents * singleQuantity)}</p>
                   </div>
                 </div>
               ) : (
@@ -129,7 +132,7 @@ function CheckoutContent() {
               <div className="border-t border-border mt-4 pt-4">
                 <div className="flex justify-between font-bold">
                   <span>Total</span>
-                  <span>{formatPrice(singleProduct ? singleProduct.priceInCents : totalPrice)}</span>
+                  <span>{formatPrice(singleProduct ? singleProduct.priceInCents * singleQuantity : totalPrice)}</span>
                 </div>
               </div>
 
@@ -143,7 +146,7 @@ function CheckoutContent() {
           {/* Checkout form */}
           <div className="lg:col-span-3 order-1 lg:order-2">
             <h1 className="text-2xl font-bold mb-6">Checkout</h1>
-            <Checkout productId={singleProduct?.id} />
+            <Checkout productId={singleProduct?.id} quantity={singleQuantity} />
           </div>
         </div>
       </div>

--- a/app/product/[id]/product-detail-client.tsx
+++ b/app/product/[id]/product-detail-client.tsx
@@ -17,7 +17,7 @@ import { ProductReviews } from "@/components/product-reviews"
 import { WishlistButton } from "@/components/wishlist-button"
 import { Breadcrumbs } from "@/components/breadcrumbs"
 import { TrustBadges } from "@/components/trust-badges"
-import { ShoppingBag, Check, Shield, RotateCcw, Plus, Package, Zap, Award, Sparkles } from "lucide-react"
+import { ShoppingBag, Check, Shield, RotateCcw, Plus, Minus, Package, Zap, Award, Sparkles } from "lucide-react"
 import { StickyAddToCart } from "@/components/sticky-add-to-cart"
 import { RecentlyViewed } from "@/components/recently-viewed"
 
@@ -30,16 +30,22 @@ export function ProductDetailClient({ product, relatedProducts }: ProductDetailC
   const [justAdded, setJustAdded] = useState(false)
   const [showUpsell, setShowUpsell] = useState(false)
   const [addedUpsells, setAddedUpsells] = useState<Set<string>>(new Set())
+  const [quantity, setQuantity] = useState(1)
   const { addItem } = useCart()
 
+  const maxQuantity = typeof product.stockCount === "number" ? product.stockCount : 10
+
   const handleAddToCart = () => {
-    addItem(product)
+    addItem(product, quantity)
     setJustAdded(true)
     if (product.category === "camera") {
       setShowUpsell(true)
     }
     setTimeout(() => setJustAdded(false), 2000)
   }
+
+  const decrementQty = () => setQuantity((q) => Math.max(1, q - 1))
+  const incrementQty = () => setQuantity((q) => Math.min(maxQuantity, q + 1))
 
   const handleAddUpsell = (upsell: Product) => {
     addItem(upsell)
@@ -158,6 +164,43 @@ export function ProductDetailClient({ product, relatedProducts }: ProductDetailC
 
               {/* Actions - Updated heart button to WishlistButton component */}
               <div className="mt-8 space-y-3">
+                {/* Quantity selector */}
+                {product.inStock && (
+                  <div className="flex items-center justify-between p-3 border-2 border-border rounded-xl">
+                    <span className="text-sm font-medium">Quantity</span>
+                    <div className="flex items-center gap-3">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        className="h-9 w-9 rounded-lg"
+                        onClick={decrementQty}
+                        disabled={quantity <= 1}
+                        aria-label="Decrease quantity"
+                      >
+                        <Minus className="h-4 w-4" />
+                      </Button>
+                      <span className="font-bold text-lg w-8 text-center">{quantity}</span>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        className="h-9 w-9 rounded-lg"
+                        onClick={incrementQty}
+                        disabled={quantity >= maxQuantity}
+                        aria-label="Increase quantity"
+                      >
+                        <Plus className="h-4 w-4" />
+                      </Button>
+                      {typeof product.stockCount === "number" && (
+                        <span className="text-xs text-muted-foreground ml-2">
+                          {product.stockCount} available
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                )}
+
                 <div className="flex gap-3">
                   <Button
                     size="lg"
@@ -187,7 +230,7 @@ export function ProductDetailClient({ product, relatedProducts }: ProductDetailC
                   asChild
                   disabled={!product.inStock}
                 >
-                  <Link href={`/checkout?product=${product.id}`}>
+                  <Link href={`/checkout?product=${product.id}&qty=${quantity}`}>
                     <ShoppingBag className="h-5 w-5 mr-2" />
                     Buy Now
                   </Link>

--- a/components/cart-drawer.tsx
+++ b/components/cart-drawer.tsx
@@ -82,6 +82,8 @@ export function CartDrawer({ open, onClose }: CartDrawerProps) {
             <div className="flex-1 overflow-y-auto p-6 space-y-4">
               {items.map((item) => {
                 const itemSubtotal = item.product.priceInCents * item.quantity
+                const maxStock = typeof item.product.stockCount === "number" ? item.product.stockCount : undefined
+                const atMaxStock = maxStock !== undefined && item.quantity >= maxStock
 
                 return (
                   <div key={item.product.id} className="flex gap-4 group">
@@ -104,6 +106,9 @@ export function CartDrawer({ open, onClose }: CartDrawerProps) {
                         </h3>
                       </Link>
                       <p className="text-xs text-muted-foreground mt-1">{item.product.brand}</p>
+                      {atMaxStock && (
+                        <p className="text-xs text-pop-orange mt-1 font-medium">Only {maxStock} in stock</p>
+                      )}
 
                       <div className="flex items-center justify-between mt-3">
                         <div className="flex items-center gap-1 bg-secondary rounded-lg p-1 border border-border">
@@ -119,8 +124,10 @@ export function CartDrawer({ open, onClose }: CartDrawerProps) {
                           <Button
                             variant="ghost"
                             size="icon"
-                            className="h-7 w-7 rounded hover:bg-background"
+                            className="h-7 w-7 rounded hover:bg-background disabled:opacity-40"
                             onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
+                            disabled={atMaxStock}
+                            aria-label="Increase quantity"
                           >
                             <Plus className="h-3 w-3" />
                           </Button>

--- a/components/checkout.tsx
+++ b/components/checkout.tsx
@@ -10,9 +10,10 @@ import Link from "next/link"
 
 interface CheckoutProps {
   productId?: string
+  quantity?: number
 }
 
-export default function Checkout({ productId }: CheckoutProps) {
+export default function Checkout({ productId, quantity = 1 }: CheckoutProps) {
   const { items, clearCart } = useCart()
   const { userId } = useAuth()
   const [error, setError] = useState<string | null>(null)
@@ -24,7 +25,7 @@ export default function Checkout({ productId }: CheckoutProps) {
 
         let url: string | null
         if (productId) {
-          url = await startSingleProductCheckout(productId, uid)
+          url = await startSingleProductCheckout(productId, uid, quantity)
         } else {
           const cartItems = items.map((item) => ({
             productId: item.product.id,
@@ -48,7 +49,7 @@ export default function Checkout({ productId }: CheckoutProps) {
     if (items.length > 0 || productId) {
       redirectToCheckout()
     }
-  }, [productId, items, userId])
+  }, [productId, quantity, items, userId])
 
   if (error) {
     return (

--- a/lib/cart-context.tsx
+++ b/lib/cart-context.tsx
@@ -10,7 +10,7 @@ export interface CartItem {
 
 interface CartContextType {
   items: CartItem[]
-  addItem: (product: Product) => void
+  addItem: (product: Product, quantity?: number) => void
   removeItem: (productId: string) => void
   updateQuantity: (productId: string, quantity: number) => void
   clearCart: () => void
@@ -19,6 +19,14 @@ interface CartContextType {
 }
 
 const CartContext = createContext<CartContextType | undefined>(undefined)
+
+// Clamp quantity to available stock. If stockCount is undefined, no limit applied.
+function clampToStock(product: Product, quantity: number): number {
+  const max = typeof product.stockCount === "number" ? product.stockCount : Infinity
+  if (quantity > max) return max
+  if (quantity < 1) return 1
+  return quantity
+}
 
 export function CartProvider({ children }: { children: ReactNode }) {
   const [items, setItems] = useState<CartItem[]>([])
@@ -44,13 +52,17 @@ export function CartProvider({ children }: { children: ReactNode }) {
     }
   }, [items, isHydrated])
 
-  const addItem = (product: Product) => {
+  const addItem = (product: Product, quantity: number = 1) => {
     setItems((prev) => {
       const existing = prev.find((item) => item.product.id === product.id)
       if (existing) {
-        return prev.map((item) => (item.product.id === product.id ? { ...item, quantity: item.quantity + 1 } : item))
+        const newQty = clampToStock(product, existing.quantity + quantity)
+        return prev.map((item) =>
+          item.product.id === product.id ? { ...item, quantity: newQty } : item
+        )
       }
-      return [...prev, { product, quantity: 1 }]
+      const clampedQty = clampToStock(product, quantity)
+      return [...prev, { product, quantity: clampedQty }]
     })
   }
 
@@ -63,7 +75,13 @@ export function CartProvider({ children }: { children: ReactNode }) {
       removeItem(productId)
       return
     }
-    setItems((prev) => prev.map((item) => (item.product.id === productId ? { ...item, quantity } : item)))
+    setItems((prev) =>
+      prev.map((item) =>
+        item.product.id === productId
+          ? { ...item, quantity: clampToStock(item.product, quantity) }
+          : item
+      )
+    )
   }
 
   const clearCart = () => setItems([])


### PR DESCRIPTION
Build end-to-end quantity + stock system to prevent overselling:

- Cart context: addItem/updateQuantity clamp to product.stockCount
- Product page: quantity selector (+/-) with "X available" indicator, wired to Buy Now URL (?qty=) and Add to Cart
- Checkout page: reads qty param and displays in order summary
- Server actions: block checkout if item is out of stock or requested quantity exceeds live stockCount (throws user-visible error)
- Stripe webhook: on checkout.session.completed, decrement product.metadata.stockCount in Stripe; auto-mark inStock=false at 0
- Cart drawer + cart page: disable + button at max stock with "Only X in stock" warning

Stock is sourced from Stripe product metadata (stockCount) — single source of truth, automatically synced after every successful order.