### PR TITLE
fix(ci): install deps before Snyk scan

### DIFF
--- a/.github/workflows/daily-security-audit.yml
+++ b/.github/workflows/daily-security-audit.yml
@@ -68,6 +68,11 @@ jobs:
         with:
           node-version: '22'
 
+      # Snyk needs the dependency tree resolved — install without running
+      # postinstall scripts and with --legacy-peer-deps (React 19.2 vs Clerk)
+      - name: Install project dependencies
+        run: npm install --legacy-peer-deps --ignore-scripts
+
       - name: Install Snyk CLI
         run: npm install -g snyk
 


### PR DESCRIPTION
Snyk CLI was exiting with code 2 (CLI error) because it couldn't resolve the dependency tree without node_modules on disk. Adding an explicit `npm install --legacy-peer-deps --ignore-scripts` step before the scan.