### PR TITLE
feat(security): add 4 HTTP security headers to next.config.mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,7 +6,26 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
- 
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          // Prevent MIME-type sniffing attacks
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          // Block clickjacking — allow same-origin frames (e.g. Clerk, Stripe modals)
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          // Send origin-only referrer to cross-origin destinations
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          // Deny browser features we don't use
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
Based on the 2026-04-14 daily audit finding that 5 of 6 security headers were missing. Adding the 4 safe-to-deploy headers now; CSP skipped because it needs careful allowlisting for Clerk, Stripe, Supabase, and Gemini.

- X-Content-Type-Options: nosniff            (blocks MIME sniffing)
- X-Frame-Options: SAMEORIGIN                 (blocks clickjacking, allows
                                               Clerk/Stripe in-app iframes)
- Referrer-Policy: strict-origin-when-cross-origin
- Permissions-Policy: camera=(), microphone=(), geolocation=(),
                      interest-cohort=()      (disable unused features +
                                               opt out of FLoC)

Verified next build succeeds locally.