### PR TITLE
feat(security): add Content-Security-Policy in Report-Only mode

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,64 @@
 /** @type {import('next').NextConfig} */
+
+// Content-Security-Policy — deployed in REPORT-ONLY mode first.
+// Browsers will log violations to the console but NOT block anything.
+// Review violations for a few days in production, then:
+//   1. Tighten this policy based on real violations (remove 'unsafe-inline'
+//      etc. if nothing needs them).
+//   2. Rename the header below from `Content-Security-Policy-Report-Only`
+//      to `Content-Security-Policy` to start enforcing.
+const cspDirectives = {
+  "default-src": ["'self'"],
+  // Clerk, Stripe, Vercel Analytics all inject runtime scripts.
+  // 'unsafe-inline' + 'unsafe-eval' kept for now — Next.js ships inline
+  // scripts without nonces by default; remove once migrating to nonces.
+  "script-src": [
+    "'self'",
+    "'unsafe-inline'",
+    "'unsafe-eval'",
+    "https://*.clerk.accounts.dev",
+    "https://js.stripe.com",
+    "https://checkout.stripe.com",
+    "https://va.vercel-scripts.com",
+  ],
+  // Tailwind and Radix emit inline styles at runtime
+  "style-src": ["'self'", "'unsafe-inline'"],
+  "font-src": ["'self'", "data:"],
+  // Product images could come from many CDNs; restrict by protocol only
+  "img-src": ["'self'", "data:", "blob:", "https:"],
+  "connect-src": [
+    "'self'",
+    "https://*.clerk.accounts.dev",
+    "https://*.supabase.co",
+    "wss://*.supabase.co",
+    "https://api.stripe.com",
+    "https://checkout.stripe.com",
+    "https://generativelanguage.googleapis.com",
+    "https://vitals.vercel-insights.com",
+    "https://va.vercel-scripts.com",
+  ],
+  // Stripe Checkout and Clerk sign-in modals load in iframes
+  "frame-src": [
+    "'self'",
+    "https://*.clerk.accounts.dev",
+    "https://js.stripe.com",
+    "https://checkout.stripe.com",
+    "https://hooks.stripe.com",
+  ],
+  "worker-src": ["'self'", "blob:"],
+  "base-uri": ["'self'"],
+  "form-action": ["'self'", "https://checkout.stripe.com"],
+  "frame-ancestors": ["'self'"],
+  "object-src": ["'none'"],
+  "upgrade-insecure-requests": [],
+}
+
+const cspHeader = Object.entries(cspDirectives)
+  .map(([directive, values]) =>
+    values.length ? `${directive} ${values.join(" ")}` : directive
+  )
+  .join("; ")
+
 const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
@@ -11,17 +71,16 @@ const nextConfig = {
       {
         source: "/:path*",
         headers: [
-          // Prevent MIME-type sniffing attacks
           { key: "X-Content-Type-Options", value: "nosniff" },
-          // Block clickjacking — allow same-origin frames (e.g. Clerk, Stripe modals)
           { key: "X-Frame-Options", value: "SAMEORIGIN" },
-          // Send origin-only referrer to cross-origin destinations
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-          // Deny browser features we don't use
           {
             key: "Permissions-Policy",
             value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
           },
+          // REPORT-ONLY for safe rollout — switch to
+          // `Content-Security-Policy` to enforce after reviewing violations
+          { key: "Content-Security-Policy-Report-Only", value: cspHeader },
         ],
       },
     ]


### PR DESCRIPTION
Deploys CSP as `Content-Security-Policy-Report-Only` so browsers log violations to the console without blocking anything. Once you've let it run in production for a few days and verified nothing legitimate is being flagged, rename the header key to `Content-Security-Policy` to enforce.

Allowlist covers every third-party origin the site currently calls:
  - Clerk (*.clerk.accounts.dev)
  - Stripe (js.stripe.com, checkout.stripe.com, api.stripe.com, hooks.stripe.com)
  - Supabase (*.supabase.co + websocket)
  - Google Gemini (generativelanguage.googleapis.com)
  - Vercel Analytics (va.vercel-scripts.com, vitals.vercel-insights.com)

'unsafe-inline' and 'unsafe-eval' are kept in script-src for now — Next.js ships inline bootstrap scripts without nonces. Tightening these requires migrating to a middleware-based nonce strategy, which is a separate effort.

Verified next build succeeds.