### PR TITLE
feat(storefront): 3D-motion hero + UX/a11y/perf overhaul

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -32,6 +32,7 @@
   --pop-blue: oklch(0.55 0.18 250);
   --pop-green: oklch(0.55 0.16 165);
   --pop-teal: oklch(0.45 0.12 185);
+  --pop-red: oklch(0.6 0.24 27);
 
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
@@ -73,6 +74,7 @@
   --pop-blue: oklch(0.55 0.18 250);
   --pop-green: oklch(0.55 0.16 165);
   --pop-teal: oklch(0.45 0.12 185);
+  --pop-red: oklch(0.65 0.24 27);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
@@ -111,6 +113,7 @@
   --color-pop-green: var(--pop-green);
   --color-pop-yellow: var(--pop-yellow);
   --color-pop-teal: var(--pop-teal);
+  --color-pop-red: var(--pop-red);
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);
   --color-chart-3: var(--chart-3);
@@ -291,4 +294,48 @@ html {
       oklch(0.7 0.22 350) 8px,
       oklch(0.15 0.02 45) 8px,
       oklch(0.15 0.02 45) 16px);
+}
+
+/* Radial spotlight glow behind hero product */
+.bg-spotlight {
+  background: radial-gradient(circle at center,
+      oklch(0.92 0.2 95 / 0.55) 0%,
+      oklch(0.7 0.22 350 / 0.18) 38%,
+      transparent 70%);
+}
+
+/* 3D scene helpers for pointer-tilt / camera-style motion */
+.perspective-1000 {
+  perspective: 1000px;
+}
+
+.preserve-3d {
+  transform-style: preserve-3d;
+}
+
+/* Respect user motion preferences: kill infinite/decorative animation
+   and scroll smoothing for anyone who asks for reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .animate-marquee,
+  .animate-marquee-reverse,
+  .animate-bounce-subtle,
+  .animate-pulse-glow,
+  .animate-float,
+  .animate-shimmer::after {
+    animation: none !important;
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,12 +10,13 @@ import { TrustBanner } from "@/components/trust-banner"
 import { Newsletter } from "@/components/newsletter"
 import { Footer } from "@/components/footer"
 import { getSectionContent } from "@/lib/content"
+import { getStripeProducts } from "@/lib/stripe-products"
 
 export const revalidate = 60 // Revalidate every 60 seconds
 
 export default async function Home() {
-  // Fetch all CMS content in parallel
-  const [hero, promoBanner, trustBadges, trustBanner, trustStory, testimonials, newsletter, footer] =
+  // Fetch all CMS content + products in parallel (server-side — no client waterfall)
+  const [hero, promoBanner, trustBadges, trustBanner, trustStory, testimonials, newsletter, footer, products] =
     await Promise.all([
       getSectionContent("hero"),
       getSectionContent("promo_banner"),
@@ -25,6 +26,7 @@ export default async function Home() {
       getSectionContent("testimonials"),
       getSectionContent("newsletter"),
       getSectionContent("footer"),
+      getStripeProducts(),
     ])
 
   return (
@@ -33,8 +35,8 @@ export default async function Home() {
       <Header />
       <Hero cms={hero} />
       <CategoryGrid />
-      <FeaturedProducts />
-      <AnimatedCategories />
+      <FeaturedProducts products={products} />
+      <AnimatedCategories products={products} />
       <TestimonialsSection cms={testimonials} />
       <TrustStory cms={trustStory} />
       <TrustBanner cms={trustBanner} />

--- a/app/shop/page.tsx
+++ b/app/shop/page.tsx
@@ -12,7 +12,8 @@ import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { type Product } from "@/lib/products"
-import { Search, SlidersHorizontal, X, Grid3X3, LayoutGrid, TrendingUp, Loader2 } from "lucide-react"
+import { Search, SlidersHorizontal, X, Grid3X3, LayoutGrid, TrendingUp } from "lucide-react"
+import { Stagger, StaggerItem } from "@/components/motion/motion-primitives"
 
 const brands = [
   "All",
@@ -41,13 +42,18 @@ function ShopContent() {
   const searchParams = useSearchParams()
   const initialCategory = searchParams.get("category") || "all"
   const initialSubcategory = searchParams.get("sub") || "All"
+  const initialSearch = searchParams.get("q") || searchParams.get("search") || ""
+  const initialBrand = searchParams.get("brand") || "All"
+  const validSorts = ["featured", "price-low", "price-high", "newest"]
+  const sortParam = searchParams.get("sort") || "featured"
+  const initialSort = validSorts.includes(sortParam) ? sortParam : "featured"
 
-  const [searchQuery, setSearchQuery] = useState("")
-  const [selectedBrand, setSelectedBrand] = useState("All")
+  const [searchQuery, setSearchQuery] = useState(initialSearch)
+  const [selectedBrand, setSelectedBrand] = useState(initialBrand)
   const [selectedYear, setSelectedYear] = useState("All")
   const [selectedCategory, setSelectedCategory] = useState(initialCategory)
   const [selectedSubcategory, setSelectedSubcategory] = useState(initialSubcategory)
-  const [sortBy, setSortBy] = useState("featured")
+  const [sortBy, setSortBy] = useState(initialSort)
   const [showFilters, setShowFilters] = useState(false)
   const [gridCols, setGridCols] = useState<3 | 4>(4)
 
@@ -102,7 +108,10 @@ function ShopContent() {
     }
 
     if (selectedBrand !== "All" && selectedCategory !== "accessory") {
-      filtered = filtered.filter((p) => p.name.toLowerCase().includes(selectedBrand.toLowerCase()))
+      const brandLower = selectedBrand.toLowerCase()
+      filtered = filtered.filter(
+        (p) => p.brand?.toLowerCase() === brandLower || p.name.toLowerCase().includes(brandLower),
+      )
     }
 
     if (selectedYear !== "All" && selectedCategory !== "accessory") {
@@ -117,7 +126,7 @@ function ShopContent() {
         filtered.sort((a, b) => b.priceInCents - a.priceInCents)
         break
       case "newest":
-        filtered.sort((a, b) => Number.parseInt(b.year) - Number.parseInt(a.year))
+        filtered.sort((a, b) => Number.parseInt(b.year || "0") - Number.parseInt(a.year || "0"))
         break
       default:
         filtered.sort((a, b) => (b.badge ? 1 : 0) - (a.badge ? 1 : 0))
@@ -364,11 +373,13 @@ function ShopContent() {
 
         {/* Product grid */}
         {filteredProducts.length > 0 ? (
-          <div className={`grid grid-cols-2 gap-5 lg:gap-8 ${gridCols === 3 ? "lg:grid-cols-3" : "lg:grid-cols-4"}`}>
+          <Stagger className={`grid grid-cols-2 gap-5 lg:gap-8 ${gridCols === 3 ? "lg:grid-cols-3" : "lg:grid-cols-4"}`}>
             {filteredProducts.map((product) => (
-              <ProductCard key={product.id} product={product} />
+              <StaggerItem key={product.id}>
+                <ProductCard product={product} />
+              </StaggerItem>
             ))}
-          </div>
+          </Stagger>
         ) : (
           <div className="text-center py-20 bg-secondary/50 rounded-2xl">
             <p className="text-lg font-medium">No products found</p>

--- a/components/animated-categories.tsx
+++ b/components/animated-categories.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useMemo } from "react"
 import Link from "next/link"
+import Image from "next/image"
 import { type Product } from "@/lib/products"
-import { Loader2 } from "lucide-react"
+import { Reveal, Stagger, StaggerItem } from "@/components/motion/motion-primitives"
 
 // Color schemes for brand cards
 const colorSchemes = [
@@ -15,17 +16,17 @@ const colorSchemes = [
 
 // Brand name to product line mapping for better display
 const brandSubtitles: Record<string, string> = {
-  "Sony": "CYBERSHOT",
-  "Canon": "POWERSHOT",
-  "Fujifilm": "FINEPIX",
-  "Nikon": "COOLPIX",
-  "Olympus": "STYLUS",
-  "Kodak": "EASYSHARE",
-  "Casio": "EXILIM",
-  "Panasonic": "LUMIX",
-  "Samsung": "DIGIMAX",
-  "Pentax": "OPTIO",
-  "HP": "PHOTOSMART",
+  Sony: "CYBERSHOT",
+  Canon: "POWERSHOT",
+  Fujifilm: "FINEPIX",
+  Nikon: "COOLPIX",
+  Olympus: "STYLUS",
+  Kodak: "EASYSHARE",
+  Casio: "EXILIM",
+  Panasonic: "LUMIX",
+  Samsung: "DIGIMAX",
+  Pentax: "OPTIO",
+  HP: "PHOTOSMART",
 }
 
 interface BrandCategory {
@@ -36,6 +37,10 @@ interface BrandCategory {
   textColor: string
   image: string
   productCount: number
+}
+
+interface AnimatedCategoriesProps {
+  products?: Product[]
 }
 
 function CornerTriangle({ position, color }: { position: "tl" | "tr" | "bl" | "br"; color: string }) {
@@ -55,132 +60,96 @@ function CornerTriangle({ position, color }: { position: "tl" | "tr" | "bl" | "b
   )
 }
 
-export function AnimatedCategories() {
-  const [brandCategories, setBrandCategories] = useState<BrandCategory[]>([])
-  const [isLoading, setIsLoading] = useState(true)
+export function AnimatedCategories({ products = [] }: AnimatedCategoriesProps) {
+  const brandCategories = useMemo<BrandCategory[]>(() => {
+    const inStockProducts = products.filter((p) => p.inStock && p.brand)
 
-  useEffect(() => {
-    async function fetchBrands() {
-      try {
-        setIsLoading(true)
-        const res = await fetch("/api/products")
-        if (res.ok) {
-          const products: Product[] = await res.json()
+    const brandMap = new Map<string, Product[]>()
+    inStockProducts.forEach((product) => {
+      const brand = product.brand as string
+      if (!brandMap.has(brand)) brandMap.set(brand, [])
+      brandMap.get(brand)!.push(product)
+    })
 
-          // Only include in-stock products
-          const inStockProducts = products.filter(p => p.inStock)
-
-          // Group products by brand
-          const brandMap = new Map<string, Product[]>()
-          inStockProducts.forEach(product => {
-            const brand = product.brand
-            if (!brandMap.has(brand)) {
-              brandMap.set(brand, [])
-            }
-            brandMap.get(brand)!.push(product)
-          })
-
-          // Sort brands by product count and take top 4
-          const sortedBrands = Array.from(brandMap.entries())
-            .sort((a, b) => b[1].length - a[1].length)
-            .slice(0, 4)
-
-          // Create category objects
-          const categories: BrandCategory[] = sortedBrands.map(([brand, products], index) => ({
-            name: brand.toUpperCase(),
-            subtitle: brandSubtitles[brand] || "CAMERAS",
-            href: `/shop?brand=${encodeURIComponent(brand)}`,
-            bgColor: colorSchemes[index % colorSchemes.length].bgColor,
-            textColor: colorSchemes[index % colorSchemes.length].textColor,
-            image: products[0]?.images[0] || "/placeholder.svg",
-            productCount: products.length,
-          }))
-
-          setBrandCategories(categories)
-        }
-      } catch (error) {
-        console.error("Failed to fetch brand categories:", error)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    fetchBrands()
-  }, [])
+    return Array.from(brandMap.entries())
+      .sort((a, b) => b[1].length - a[1].length)
+      .slice(0, 4)
+      .map(([brand, brandProducts], index) => ({
+        name: brand.toUpperCase(),
+        subtitle: brandSubtitles[brand] || "CAMERAS",
+        href: `/shop?brand=${encodeURIComponent(brand)}`,
+        bgColor: colorSchemes[index % colorSchemes.length].bgColor,
+        textColor: colorSchemes[index % colorSchemes.length].textColor,
+        image: brandProducts[0]?.images[0] || "/placeholder.svg",
+        productCount: brandProducts.length,
+      }))
+  }, [products])
 
   return (
     <section className="py-12 lg:py-20 bg-background">
       <div className="mx-auto max-w-7xl px-4 lg:px-6">
         {/* Section header */}
-        <div className="text-center mb-8 lg:mb-12">
-          <span className="inline-block px-4 py-1 bg-pop-yellow text-foreground text-xs font-bold uppercase tracking-wider mb-4">
-            Shop by Brand
-          </span>
-          <h2 className="text-3xl lg:text-5xl font-black uppercase tracking-tight">
-            Your Favorite <span className="text-pop-pink">Y2K Brands</span>
-          </h2>
-          <p className="text-muted-foreground mt-2">Currently in stock</p>
-        </div>
-
-        {isLoading ? (
-          <div className="flex justify-center items-center py-20">
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <Reveal>
+          <div className="text-center mb-8 lg:mb-12">
+            <span className="inline-block px-4 py-1 bg-pop-yellow text-foreground text-xs font-bold uppercase tracking-wider mb-4 rounded-full">
+              Shop by Brand
+            </span>
+            <h2 className="text-3xl lg:text-5xl font-black uppercase tracking-tight">
+              Your Favorite <span className="text-pop-pink">Y2K Brands</span>
+            </h2>
+            <p className="text-muted-foreground mt-2">Currently in stock</p>
           </div>
-        ) : brandCategories.length > 0 ? (
-          /* Brand grid - 4 columns */
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 lg:gap-4">
+        </Reveal>
+
+        {brandCategories.length > 0 ? (
+          <Stagger className="grid grid-cols-2 lg:grid-cols-4 gap-3 lg:gap-4">
             {brandCategories.map((cat) => (
-              <Link
-                key={cat.name}
-                href={cat.href}
-                className={`group relative aspect-[3/4] ${cat.bgColor} overflow-hidden`}
-              >
-                {/* Corner triangles */}
-                <CornerTriangle position="tl" color={cat.textColor} />
-                <CornerTriangle position="tr" color={cat.textColor} />
-                <CornerTriangle position="bl" color={cat.textColor} />
-                <CornerTriangle position="br" color={cat.textColor} />
+              <StaggerItem key={cat.name}>
+                <Link
+                  href={cat.href}
+                  className={`group relative block aspect-[3/4] ${cat.bgColor} overflow-hidden rounded-xl transition-transform duration-300 hover:-translate-y-1`}
+                >
+                  <CornerTriangle position="tl" color={cat.textColor} />
+                  <CornerTriangle position="tr" color={cat.textColor} />
+                  <CornerTriangle position="bl" color={cat.textColor} />
+                  <CornerTriangle position="br" color={cat.textColor} />
 
-                <div className="absolute inset-6 lg:inset-8 flex items-center justify-center">
-                  <img
-                    src={cat.image || "/placeholder.svg"}
-                    alt={`${cat.name} ${cat.subtitle}`}
-                    className="w-full h-full object-contain mix-blend-multiply opacity-80 group-hover:scale-110 group-hover:opacity-100 transition-all duration-500"
-                  />
-                </div>
-
-                {/* Text overlay */}
-                <div className="absolute inset-0 p-3 lg:p-4 flex flex-col justify-between pointer-events-none">
-                  <div>
-                    <h3
-                      className={`text-lg sm:text-xl lg:text-2xl font-black ${cat.textColor} leading-none tracking-tight`}
-                    >
-                      {cat.name}
-                    </h3>
-                    <h3
-                      className={`text-lg sm:text-xl lg:text-2xl font-black ${cat.textColor} leading-none tracking-tight`}
-                    >
-                      {cat.subtitle}
-                    </h3>
-                    <span className={`text-xs ${cat.textColor} opacity-70 font-medium mt-1 block`}>
-                      {cat.productCount} {cat.productCount === 1 ? 'item' : 'items'} in stock
-                    </span>
+                  <div className="absolute inset-6 lg:inset-8">
+                    <Image
+                      src={cat.image}
+                      alt={`${cat.name} ${cat.subtitle}`}
+                      fill
+                      sizes="(max-width: 1024px) 50vw, 25vw"
+                      className="object-contain mix-blend-multiply opacity-80 group-hover:scale-110 group-hover:opacity-100 transition-all duration-500"
+                    />
                   </div>
 
-                  {/* Shop button */}
-                  <div className="flex justify-center pointer-events-auto">
-                    <span className="bg-foreground text-background text-xs font-bold px-5 py-2 uppercase tracking-wider group-hover:bg-background group-hover:text-foreground transition-colors">
-                      Shop
-                    </span>
+                  {/* Text overlay */}
+                  <div className="absolute inset-0 p-3 lg:p-4 flex flex-col justify-between pointer-events-none">
+                    <div>
+                      <h3 className={`text-lg sm:text-xl lg:text-2xl font-black ${cat.textColor} leading-none tracking-tight`}>
+                        {cat.name}
+                      </h3>
+                      <h3 className={`text-lg sm:text-xl lg:text-2xl font-black ${cat.textColor} leading-none tracking-tight`}>
+                        {cat.subtitle}
+                      </h3>
+                      <span className={`text-xs ${cat.textColor} opacity-70 font-medium mt-1 block`}>
+                        {cat.productCount} {cat.productCount === 1 ? "item" : "items"} in stock
+                      </span>
+                    </div>
+
+                    <div className="flex justify-center">
+                      <span className="bg-foreground text-background text-xs font-bold px-5 py-2 rounded-full uppercase tracking-wider group-hover:bg-background group-hover:text-foreground transition-colors">
+                        Shop
+                      </span>
+                    </div>
                   </div>
-                </div>
-              </Link>
+                </Link>
+              </StaggerItem>
             ))}
-          </div>
+          </Stagger>
         ) : (
-          <div className="text-center py-12 text-muted-foreground">
-            No brands available yet.
-          </div>
+          <div className="text-center py-12 text-muted-foreground">No brands available yet.</div>
         )}
       </div>
     </section>

--- a/components/featured-products.tsx
+++ b/components/featured-products.tsx
@@ -1,85 +1,66 @@
 "use client"
 
-import { useState, useEffect } from "react"
 import Link from "next/link"
 import { ProductCard } from "@/components/product-card"
 import { type Product } from "@/lib/products"
-import { ArrowRight, Loader2 } from "lucide-react"
+import { ArrowRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Reveal, Stagger, StaggerItem } from "@/components/motion/motion-primitives"
 
-export function FeaturedProducts() {
-  const [products, setProducts] = useState<Product[]>([])
-  const [isLoading, setIsLoading] = useState(true)
+interface FeaturedProductsProps {
+  products?: Product[]
+}
 
-  useEffect(() => {
-    async function fetchProducts() {
-      try {
-        setIsLoading(true)
-        const res = await fetch("/api/products")
-        if (res.ok) {
-          const data = await res.json()
-          // Take first 6 products for featured section
-          setProducts(data.slice(0, 6))
-        }
-      } catch (error) {
-        console.error("Failed to fetch featured products:", error)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-    fetchProducts()
-  }, [])
+export function FeaturedProducts({ products = [] }: FeaturedProductsProps) {
+  const featured = products.slice(0, 6)
+
+  const latestDrop = featured.length > 0 && featured[0].createdAt ? new Date(featured[0].createdAt) : new Date()
+  const latestDropLabel = latestDrop.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })
 
   return (
     <section className="py-12 lg:py-20 bg-background">
       <div className="mx-auto max-w-7xl px-4 lg:px-6">
         {/* Section header - Retrospekt style */}
-        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-8 lg:mb-12">
-          <div>
-            <span className="inline-block px-4 py-1 bg-pop-pink text-white text-xs font-bold uppercase tracking-wider mb-4">
-              Just Dropped
-            </span>
-            <h2 className="text-3xl lg:text-5xl font-black uppercase tracking-tight">
-              New <span className="text-pop-pink">Arrivals</span>
-            </h2>
-            <p className="text-sm font-mono text-muted-foreground mt-2">
-              Latest drop: {products.length > 0 && products[0].createdAt
-                ? new Date(products[0].createdAt).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })
-                : new Date().toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}
-            </p>
+        <Reveal>
+          <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-8 lg:mb-12">
+            <div>
+              <span className="inline-block px-4 py-1 bg-pop-pink text-white text-xs font-bold uppercase tracking-wider mb-4 rounded-full">
+                Just Dropped
+              </span>
+              <h2 className="text-3xl lg:text-5xl font-black uppercase tracking-tight">
+                New <span className="text-pop-pink">Arrivals</span>
+              </h2>
+              <p className="text-sm font-mono text-muted-foreground mt-2">Latest drop: {latestDropLabel}</p>
+            </div>
+            <Button
+              variant="outline"
+              className="gap-2 group border-2 border-foreground bg-transparent hover:bg-foreground hover:text-background transition-all font-bold uppercase tracking-wide rounded-full"
+              asChild
+            >
+              <Link href="/shop">
+                See All
+                <ArrowRight className="h-4 w-4 group-hover:translate-x-0.5 transition-transform" />
+              </Link>
+            </Button>
           </div>
-          <Button
-            variant="outline"
-            className="gap-2 group border-2 border-foreground bg-transparent hover:bg-foreground hover:text-background transition-all font-bold uppercase tracking-wide"
-            asChild
-          >
-            <Link href="/shop">
-              See All
-              <ArrowRight className="h-4 w-4 group-hover:translate-x-0.5 transition-transform" />
-            </Link>
-          </Button>
-        </div>
+        </Reveal>
 
         {/* Product grid */}
-        {isLoading ? (
-          <div className="flex justify-center items-center py-20">
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-          </div>
-        ) : products.length > 0 ? (
-          <div className="grid grid-cols-2 lg:grid-cols-3 gap-3 lg:gap-5">
-            {products.map((product) => (
-              <ProductCard key={product.id} product={product} />
+        {featured.length > 0 ? (
+          <Stagger className="grid grid-cols-2 lg:grid-cols-3 gap-3 lg:gap-5">
+            {featured.map((product) => (
+              <StaggerItem key={product.id}>
+                <ProductCard product={product} />
+              </StaggerItem>
             ))}
-          </div>
+          </Stagger>
         ) : (
-          <div className="text-center py-20 text-muted-foreground">
-            No products available yet.
-          </div>
+          <div className="text-center py-20 text-muted-foreground">No products available yet.</div>
         )}
 
         {/* Bottom CTA - mobile */}
         <div className="mt-8 lg:hidden">
-          <Button className="w-full h-12 gap-2 bg-foreground font-bold uppercase tracking-wide" asChild>
+          <Button className="w-full h-12 gap-2 bg-foreground font-bold uppercase tracking-wide rounded-full" asChild>
             <Link href="/shop">
               View All Products
               <ArrowRight className="h-4 w-4" />

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,9 +1,11 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import { Menu, X, ShoppingBag, Search, ChevronDown, Heart } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { useCart } from "@/lib/cart-context"
 import { CartDrawer } from "@/components/cart-drawer"
 import { SignedIn, SignedOut, UserButton, useUser } from "@clerk/nextjs"
@@ -24,7 +26,11 @@ export function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [scrolled, setScrolled] = useState(false)
   const [cartOpen, setCartOpen] = useState(false)
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState("")
+  const searchInputRef = useRef<HTMLInputElement>(null)
   const { totalItems } = useCart()
+  const router = useRouter()
 
   useEffect(() => {
     const handleScroll = () => setScrolled(window.scrollY > 10)
@@ -32,78 +38,83 @@ export function Header() {
     return () => window.removeEventListener("scroll", handleScroll)
   }, [])
 
+  useEffect(() => {
+    if (searchOpen) searchInputRef.current?.focus()
+  }, [searchOpen])
+
+  const submitSearch = (e: React.FormEvent) => {
+    e.preventDefault()
+    const q = searchQuery.trim()
+    router.push(q ? `/shop?q=${encodeURIComponent(q)}` : "/shop")
+    setSearchOpen(false)
+    setSearchQuery("")
+  }
+
   return (
     <>
       <header
-        className={`sticky top-0 z-40 transition-all duration-300 ${scrolled ? "bg-background/95 backdrop-blur-xl border-b-2 border-foreground" : "bg-background"
-          }`}
+        className={`sticky top-0 z-40 transition-all duration-300 ${
+          scrolled ? "bg-background/95 backdrop-blur-xl border-b-2 border-foreground" : "bg-background border-b-2 border-transparent"
+        }`}
       >
-        <nav className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 lg:px-6">
-          {/* Mobile menu button */}
-          <Button variant="ghost" size="icon" className="lg:hidden" onClick={() => setMobileMenuOpen(true)}>
-            <Menu className="h-5 w-5" />
-            <span className="sr-only">Open menu</span>
-          </Button>
+        <nav className="mx-auto grid max-w-7xl grid-cols-[1fr_auto_1fr] items-center px-4 py-3 lg:px-6">
+          {/* Left: mobile menu button + desktop nav */}
+          <div className="flex items-center justify-start">
+            <Button variant="ghost" size="icon" className="lg:hidden cursor-pointer" onClick={() => setMobileMenuOpen(true)}>
+              <Menu className="h-5 w-5" />
+              <span className="sr-only">Open menu</span>
+            </Button>
 
-          {/* Desktop navigation - left */}
-          <div className="hidden lg:flex lg:items-center lg:gap-1">
-            {navigation.map((item) => (
-              <Link
-                key={item.name}
-                href={item.href}
-                className={`px-4 py-2 text-xs font-bold uppercase tracking-wider transition-colors ${item.featured
-                  ? "bg-foreground text-background hover:bg-pop-pink"
-                  : "text-foreground/70 hover:text-foreground hover:bg-secondary"
+            <div className="hidden lg:flex lg:items-center lg:gap-1">
+              {navigation.map((item) => (
+                <Link
+                  key={item.name}
+                  href={item.href}
+                  className={`px-4 py-2 text-xs font-bold uppercase tracking-wider transition-colors rounded-full ${
+                    item.featured
+                      ? "bg-foreground text-background hover:bg-pop-pink"
+                      : "text-foreground/70 hover:text-foreground hover:bg-secondary"
                   }`}
-              >
-                {item.name}
-              </Link>
-            ))}
+                >
+                  {item.name}
+                </Link>
+              ))}
+            </div>
           </div>
 
-          {/* Logo - center */}
-          <Link
-            href="/"
-            className="flex items-center gap-2 group absolute left-1/2 -translate-x-1/2 lg:static lg:translate-x-0 lg:absolute lg:left-1/2 lg:-translate-x-1/2"
-          >
+          {/* Center: logo */}
+          <Link href="/" className="group flex items-center justify-center">
             <div className="relative">
               <span className="text-lg lg:text-xl font-black tracking-tight uppercase">Measure Joy</span>
               <span className="absolute -top-1 -right-6 text-[9px] font-mono font-bold text-pop-pink">Y2K</span>
             </div>
           </Link>
 
-          {/* Right side actions */}
-          <div className="flex items-center gap-1">
-            <Button variant="ghost" size="icon" className="hidden sm:flex" asChild>
-              <Link href="/shop">
-                <Search className="h-5 w-5" />
-                <span className="sr-only">Search</span>
-              </Link>
+          {/* Right: actions */}
+          <div className="flex items-center justify-end gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="hidden sm:flex cursor-pointer"
+              onClick={() => setSearchOpen((o) => !o)}
+              aria-label="Search"
+              aria-expanded={searchOpen}
+            >
+              <Search className="h-5 w-5" />
             </Button>
 
-            {/* Wishlist link - only show when signed in */}
             <SignedIn>
-              <Button variant="ghost" size="icon" className="hidden sm:flex" asChild>
+              <AdminLink />
+              <Button variant="ghost" size="icon" className="hidden sm:flex cursor-pointer" asChild>
                 <Link href="/account/wishlist">
                   <Heart className="h-5 w-5" />
                   <span className="sr-only">Wishlist</span>
                 </Link>
               </Button>
-            </SignedIn>
-
-            {/* User button - Clerk handles sign in/out */}
-            <SignedIn>
-              <UserButton
-                afterSignOutUrl="/"
-                appearance={{
-                  elements: {
-                    avatarBox: "w-8 h-8"
-                  }
-                }}
-              />
+              <UserButton afterSignOutUrl="/" appearance={{ elements: { avatarBox: "w-8 h-8" } }} />
             </SignedIn>
             <SignedOut>
-              <Button variant="ghost" size="icon" asChild>
+              <Button variant="ghost" size="icon" className="cursor-pointer" asChild>
                 <Link href="/sign-in">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -124,10 +135,10 @@ export function Header() {
               </Button>
             </SignedOut>
 
-            <Button variant="ghost" size="icon" className="relative" onClick={() => setCartOpen(true)}>
+            <Button variant="ghost" size="icon" className="relative cursor-pointer" onClick={() => setCartOpen(true)}>
               <ShoppingBag className="h-5 w-5" />
               {totalItems > 0 && (
-                <span className="absolute -top-0.5 -right-0.5 h-5 w-5 bg-pop-pink text-[10px] font-bold text-white flex items-center justify-center">
+                <span className="absolute -top-0.5 -right-0.5 h-5 w-5 rounded-full bg-pop-pink text-[10px] font-bold text-white flex items-center justify-center">
                   {totalItems}
                 </span>
               )}
@@ -136,16 +147,58 @@ export function Header() {
           </div>
         </nav>
 
+        {/* Search bar (expands under nav) */}
+        {searchOpen && (
+          <div className="border-t border-border bg-background">
+            <form onSubmit={submitSearch} className="mx-auto max-w-7xl px-4 lg:px-6 py-3">
+              <div className="relative">
+                <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  ref={searchInputRef}
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search cameras, brands, accessories..."
+                  className="pl-11 pr-24 h-12 rounded-full bg-secondary border-0"
+                />
+                <Button
+                  type="submit"
+                  size="sm"
+                  className="absolute right-1.5 top-1/2 -translate-y-1/2 h-9 rounded-full font-bold uppercase tracking-wide cursor-pointer"
+                >
+                  Search
+                </Button>
+              </div>
+            </form>
+          </div>
+        )}
+
         {/* Mobile menu - full screen overlay */}
         {mobileMenuOpen && (
           <div className="lg:hidden fixed inset-0 z-50 bg-background overflow-hidden">
             <div className="flex items-center justify-between px-4 py-3 border-b-2 border-foreground bg-background">
               <span className="text-lg font-black tracking-tight uppercase">Measure Joy</span>
-              <Button variant="ghost" size="icon" onClick={() => setMobileMenuOpen(false)}>
+              <Button variant="ghost" size="icon" className="cursor-pointer" onClick={() => setMobileMenuOpen(false)}>
                 <X className="h-5 w-5" />
               </Button>
             </div>
-            <div className="p-6 bg-background h-[calc(100vh-60px)] overflow-y-auto">
+            <div className="p-6 bg-background h-[calc(100dvh-60px)] overflow-y-auto">
+              {/* Mobile search */}
+              <form
+                onSubmit={(e) => {
+                  submitSearch(e)
+                  setMobileMenuOpen(false)
+                }}
+                className="relative mb-6"
+              >
+                <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search products..."
+                  className="pl-11 h-12 rounded-full bg-secondary border-0"
+                />
+              </form>
+
               <nav className="space-y-1">
                 {navigation.map((item) => (
                   <Link
@@ -190,10 +243,8 @@ export function Header() {
               </nav>
 
               {/* Mobile promo */}
-              <div className="mt-8 p-5 bg-pop-yellow">
-                <p className="font-mono text-xs text-foreground font-bold uppercase tracking-wide mb-2">
-                  ★ Limited Time
-                </p>
+              <div className="mt-8 p-5 bg-pop-yellow rounded-2xl">
+                <p className="font-mono text-xs text-foreground font-bold uppercase tracking-wide mb-2">★ Limited Time</p>
                 <p className="text-lg font-bold text-foreground">Free shipping on orders $75+</p>
               </div>
             </div>
@@ -206,9 +257,10 @@ export function Header() {
     </>
   )
 }
+
 function MobileAdminLink({ setOpen }: { setOpen: (open: boolean) => void }) {
   const { user } = useUser()
-  if (user?.publicMetadata?.role !== 'admin') return null
+  if (user?.publicMetadata?.role !== "admin") return null
 
   return (
     <Link
@@ -224,12 +276,12 @@ function MobileAdminLink({ setOpen }: { setOpen: (open: boolean) => void }) {
 
 function AdminLink() {
   const { user } = useUser()
-  if (user?.publicMetadata?.role !== 'admin') return null
+  if (user?.publicMetadata?.role !== "admin") return null
 
   return (
     <Link
       href="/admin/orders"
-      className="hidden lg:flex items-center gap-2 px-4 py-2 text-xs font-bold uppercase tracking-wider text-pop-pink hover:bg-secondary transition-colors"
+      className="hidden lg:flex items-center gap-2 px-4 py-2 text-xs font-bold uppercase tracking-wider text-pop-pink hover:bg-secondary rounded-full transition-colors"
     >
       Admin
     </Link>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -1,8 +1,12 @@
 "use client"
 
+import { useRef } from "react"
 import Link from "next/link"
+import Image from "next/image"
 import { Button } from "@/components/ui/button"
-import { ArrowRight } from "lucide-react"
+import { ArrowRight, Star, ShieldCheck, Sparkles } from "lucide-react"
+import { motion, useReducedMotion, useScroll, useTransform } from "motion/react"
+import { TiltCard } from "@/components/motion/motion-primitives"
 
 interface HeroProps {
   cms?: Record<string, any>
@@ -13,9 +17,11 @@ const DEFAULTS = {
   heading_line1: "Reviving",
   heading_line2: "Y2K Tech",
   heading_line3: "For You",
-  subtitle: "Curated vintage digital cameras tested, cleaned, and ready to shoot. Experience the magic of early digital photography.",
+  subtitle:
+    "Curated vintage digital cameras tested, cleaned, and ready to shoot. Experience the magic of early digital photography.",
   cta_primary: "Shop All Cameras",
   cta_secondary: "Our Story",
+  hero_image: "/colorful-digital-cameras-pink-blue-y2k-aesthetic.jpg",
   marquee_items: [
     "TESTED & WORKING",
     "90-DAY WARRANTY",
@@ -26,51 +32,157 @@ const DEFAULTS = {
   ],
 }
 
+// On-load entrance for the left column (above the fold → animate on mount).
+const containerVariants = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.1, delayChildren: 0.05 } },
+}
+const itemVariants = {
+  hidden: { opacity: 0, y: 24 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: [0.22, 1, 0.36, 1] as const } },
+}
+
 export function Hero({ cms = {} }: HeroProps) {
   const c = { ...DEFAULTS, ...cms }
   const marqueeItems: string[] = Array.isArray(c.marquee_items) ? c.marquee_items : DEFAULTS.marquee_items
 
+  const reduce = useReducedMotion()
+  const sectionRef = useRef<HTMLElement>(null)
+  const { scrollYProgress } = useScroll({ target: sectionRef, offset: ["start start", "end start"] })
+
+  // Scroll-linked parallax: layers drift at different rates as you scroll past.
+  const yCamera = useTransform(scrollYProgress, [0, 1], [0, reduce ? 0 : -70])
+  const yGlow = useTransform(scrollYProgress, [0, 1], [0, reduce ? 0 : 50])
+  const yChipTop = useTransform(scrollYProgress, [0, 1], [0, reduce ? 0 : -110])
+  const yChipBottom = useTransform(scrollYProgress, [0, 1], [0, reduce ? 0 : 90])
+
   return (
-    <section className="relative overflow-hidden bg-background">
+    <section ref={sectionRef} className="relative overflow-hidden bg-background">
       <div className="absolute inset-0 bg-dot-pattern pointer-events-none" aria-hidden="true" />
 
-      <div className="relative mx-auto max-w-7xl px-4 pt-8 pb-6 lg:px-6 lg:pt-12 lg:pb-10">
-        <div className="text-center max-w-5xl mx-auto mb-8 lg:mb-12">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-pop-yellow rounded-full mb-6 shadow-sm border border-foreground/10 animate-pulse-glow">
-            <span className="font-mono text-[10px] sm:text-xs font-bold text-foreground uppercase tracking-[0.2em]">
-              {c.badge}
-            </span>
-          </div>
+      <div className="relative mx-auto max-w-7xl px-4 pt-10 pb-10 lg:px-6 lg:pt-16 lg:pb-20">
+        <div className="grid items-center gap-10 lg:grid-cols-2 lg:gap-12">
+          {/* Left: copy */}
+          <motion.div
+            className="text-center lg:text-left"
+            variants={reduce ? undefined : containerVariants}
+            initial={reduce ? undefined : "hidden"}
+            animate={reduce ? undefined : "show"}
+          >
+            <motion.div variants={reduce ? undefined : itemVariants}>
+              <span className="inline-flex items-center gap-2 px-4 py-2 bg-pop-yellow rounded-full mb-6 shadow-sm border border-foreground/10 animate-pulse-glow">
+                <Sparkles className="h-3.5 w-3.5 text-foreground" aria-hidden="true" />
+                <span className="font-mono text-[10px] sm:text-xs font-bold text-foreground uppercase tracking-[0.2em]">
+                  {c.badge}
+                </span>
+              </span>
+            </motion.div>
 
-          <h1 className="text-5xl sm:text-6xl lg:text-8xl font-black leading-[0.85] tracking-[-0.05em] mb-8 uppercase drop-shadow-sm">
-            <span className="block hover:text-pop-pink transition-colors duration-300 cursor-default">{c.heading_line1}</span>
-            <span className="block text-pop-pink tracking-[-0.08em]">{c.heading_line2}</span>
-            <span className="block italic hover:text-pop-blue transition-colors duration-300 cursor-default">{c.heading_line3}</span>
-          </h1>
-
-          <p className="text-lg lg:text-xl text-muted-foreground/80 max-w-2xl mx-auto leading-relaxed mb-10 font-medium balance">
-            {c.subtitle}
-          </p>
-
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-            <Button
-              size="lg"
-              className="h-14 px-10 text-base font-bold gap-2 group uppercase tracking-wider bg-foreground hover:bg-foreground/90 transition-all hover:scale-105 active:scale-95 hover:shadow-[0_0_30px_rgba(0,0,0,0.3)] animate-shimmer"
-              asChild
+            <motion.h1
+              variants={reduce ? undefined : itemVariants}
+              className="text-5xl sm:text-6xl lg:text-7xl xl:text-8xl font-black leading-[0.85] tracking-[-0.05em] mb-6 uppercase drop-shadow-sm"
             >
-              <Link href="/shop">
-                {c.cta_primary}
-                <ArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
-              </Link>
-            </Button>
-            <Button
-              size="lg"
-              variant="outline"
-              className="h-14 px-10 text-base font-bold uppercase tracking-wider border-2 border-foreground/10 bg-transparent hover:bg-secondary hover:border-foreground/20 transition-all hover:scale-105 active:scale-95"
-              asChild
+              <span className="block hover:text-pop-pink transition-colors duration-300 cursor-default">
+                {c.heading_line1}
+              </span>
+              <span className="block text-pop-pink tracking-[-0.08em]">{c.heading_line2}</span>
+              <span className="block italic hover:text-pop-blue transition-colors duration-300 cursor-default">
+                {c.heading_line3}
+              </span>
+            </motion.h1>
+
+            <motion.p
+              variants={reduce ? undefined : itemVariants}
+              className="text-lg lg:text-xl text-muted-foreground max-w-xl mx-auto lg:mx-0 leading-relaxed mb-8 font-medium text-pretty"
             >
-              <Link href="/about">{c.cta_secondary}</Link>
-            </Button>
+              {c.subtitle}
+            </motion.p>
+
+            <motion.div
+              variants={reduce ? undefined : itemVariants}
+              className="flex flex-col sm:flex-row items-center lg:items-start justify-center lg:justify-start gap-4"
+            >
+              <Button
+                size="lg"
+                className="h-14 px-10 text-base font-bold gap-2 group uppercase tracking-wider bg-foreground hover:bg-foreground/90 transition-all hover:shadow-[0_0_30px_rgba(0,0,0,0.3)]"
+                asChild
+              >
+                <Link href="/shop">
+                  {c.cta_primary}
+                  <ArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
+                </Link>
+              </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                className="h-14 px-10 text-base font-bold uppercase tracking-wider border-2 border-foreground/15 bg-transparent hover:bg-secondary hover:border-foreground/30 transition-all"
+                asChild
+              >
+                <Link href="/about">{c.cta_secondary}</Link>
+              </Button>
+            </motion.div>
+
+            {/* Mini trust row */}
+            <motion.div
+              variants={reduce ? undefined : itemVariants}
+              className="mt-8 flex flex-wrap items-center justify-center lg:justify-start gap-x-6 gap-y-2 text-xs font-bold uppercase tracking-wider text-muted-foreground"
+            >
+              <span className="flex items-center gap-1.5">
+                <ShieldCheck className="h-4 w-4 text-pop-teal" aria-hidden="true" />
+                90-day warranty
+              </span>
+              <span className="flex items-center gap-1.5">
+                <Star className="h-4 w-4 fill-pop-yellow text-pop-yellow" aria-hidden="true" />
+                4.9 average rating
+              </span>
+            </motion.div>
+          </motion.div>
+
+          {/* Right: 3D showcase camera */}
+          <div className="relative">
+            {/* Spotlight glow */}
+            <motion.div
+              aria-hidden="true"
+              style={{ y: yGlow }}
+              className="absolute inset-0 -z-10 bg-spotlight blur-2xl scale-110"
+            />
+
+            <motion.div style={{ y: yCamera }}>
+              <TiltCard intensity={9} lift={30} className="mx-auto max-w-md">
+                <div className="relative aspect-[4/5] overflow-hidden rounded-2xl border-2 border-foreground bg-card shadow-[8px_8px_0_0_var(--foreground)]">
+                  <Image
+                    src={c.hero_image}
+                    alt="Curated collection of vintage Y2K digital cameras"
+                    fill
+                    sizes="(max-width: 1024px) 90vw, 40vw"
+                    priority
+                    className="object-cover"
+                  />
+                  {/* Viewfinder corner ticks for camera-shop flavor */}
+                  <span className="pointer-events-none absolute left-3 top-3 h-5 w-5 border-l-2 border-t-2 border-white/80" aria-hidden="true" />
+                  <span className="pointer-events-none absolute right-3 top-3 h-5 w-5 border-r-2 border-t-2 border-white/80" aria-hidden="true" />
+                  <span className="pointer-events-none absolute left-3 bottom-3 h-5 w-5 border-l-2 border-b-2 border-white/80" aria-hidden="true" />
+                  <span className="pointer-events-none absolute right-3 bottom-3 h-5 w-5 border-r-2 border-b-2 border-white/80" aria-hidden="true" />
+                </div>
+              </TiltCard>
+            </motion.div>
+
+            {/* Floating chips (parallax) */}
+            <motion.div
+              style={{ y: yChipTop }}
+              className="absolute -top-2 -left-1 sm:left-4 z-10 flex items-center gap-2 rounded-full border-2 border-foreground bg-pop-pink px-4 py-2 shadow-[3px_3px_0_0_var(--foreground)]"
+            >
+              <Star className="h-4 w-4 fill-white text-white" aria-hidden="true" />
+              <span className="text-xs font-black uppercase tracking-wide text-white">Tested &amp; working</span>
+            </motion.div>
+
+            <motion.div
+              style={{ y: yChipBottom }}
+              className="absolute -bottom-3 right-0 sm:right-4 z-10 flex items-center gap-2 rounded-full border-2 border-foreground bg-pop-yellow px-4 py-2 shadow-[3px_3px_0_0_var(--foreground)]"
+            >
+              <ShieldCheck className="h-4 w-4 text-foreground" aria-hidden="true" />
+              <span className="text-xs font-black uppercase tracking-wide text-foreground">Free returns</span>
+            </motion.div>
           </div>
         </div>
       </div>
@@ -78,7 +190,7 @@ export function Hero({ cms = {} }: HeroProps) {
       <div className="border-y-2 border-foreground overflow-hidden bg-pop-yellow">
         <div className="flex animate-marquee whitespace-nowrap py-3">
           {[...Array(4)].map((_, i) => (
-            <div key={i} className="flex items-center gap-8 px-4">
+            <div key={i} className="flex items-center gap-8 px-4" aria-hidden={i > 0}>
               {marqueeItems.map((text) => (
                 <span
                   key={text}

--- a/components/motion/motion-primitives.tsx
+++ b/components/motion/motion-primitives.tsx
@@ -1,0 +1,216 @@
+"use client"
+
+/**
+ * Shared Framer Motion (motion/react) primitives for Measure Joy.
+ *
+ * Everything here honours `prefers-reduced-motion`: when the user opts out,
+ * elements render in their final state with no transform/opacity animation.
+ *
+ * - <Reveal>        fade + rise as the element scrolls into view
+ * - <Stagger> / <StaggerItem>  orchestrate a sequence of child reveals
+ * - <TiltCard>      pointer-driven 3D tilt (the "camera moving on graphics" feel)
+ */
+
+import type { ReactNode } from "react"
+import { useRef } from "react"
+import {
+  motion,
+  useReducedMotion,
+  useMotionValue,
+  useSpring,
+  useTransform,
+  type Variants,
+} from "motion/react"
+
+type Direction = "up" | "down" | "left" | "right" | "none"
+
+const OFFSET = 28
+
+function hiddenOffset(direction: Direction) {
+  switch (direction) {
+    case "up":
+      return { y: OFFSET, x: 0 }
+    case "down":
+      return { y: -OFFSET, x: 0 }
+    case "left":
+      return { x: OFFSET, y: 0 }
+    case "right":
+      return { x: -OFFSET, y: 0 }
+    default:
+      return { x: 0, y: 0 }
+  }
+}
+
+interface RevealProps {
+  children: ReactNode
+  className?: string
+  /** Direction the element travels from. Default "up". */
+  direction?: Direction
+  /** Seconds to wait before animating. Default 0. */
+  delay?: number
+  /** Animation duration in seconds. Default 0.6. */
+  duration?: number
+  /** Re-run the animation every time it enters the viewport. Default true (once). */
+  once?: boolean
+  as?: "div" | "section" | "li" | "span"
+}
+
+export function Reveal({
+  children,
+  className,
+  direction = "up",
+  delay = 0,
+  duration = 0.6,
+  once = true,
+  as = "div",
+}: RevealProps) {
+  const reduce = useReducedMotion()
+  const MotionTag = motion[as]
+
+  if (reduce) {
+    const Tag = as
+    return <Tag className={className}>{children}</Tag>
+  }
+
+  const offset = hiddenOffset(direction)
+
+  return (
+    <MotionTag
+      className={className}
+      initial={{ opacity: 0, ...offset }}
+      whileInView={{ opacity: 1, x: 0, y: 0 }}
+      viewport={{ once, amount: 0.2, margin: "0px 0px -80px 0px" }}
+      transition={{ duration, delay, ease: [0.22, 1, 0.36, 1] }}
+    >
+      {children}
+    </MotionTag>
+  )
+}
+
+const STAGGER_CONTAINER: Variants = {
+  hidden: {},
+  show: {
+    transition: { staggerChildren: 0.09, delayChildren: 0.05 },
+  },
+}
+
+const STAGGER_ITEM: Variants = {
+  hidden: { opacity: 0, y: 24 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.6, ease: [0.22, 1, 0.36, 1] },
+  },
+}
+
+interface StaggerProps {
+  children: ReactNode
+  className?: string
+  once?: boolean
+  as?: "div" | "section" | "ul"
+}
+
+export function Stagger({ children, className, once = true, as = "div" }: StaggerProps) {
+  const reduce = useReducedMotion()
+  const MotionTag = motion[as]
+
+  if (reduce) {
+    const Tag = as
+    return <Tag className={className}>{children}</Tag>
+  }
+
+  return (
+    <MotionTag
+      className={className}
+      variants={STAGGER_CONTAINER}
+      initial="hidden"
+      whileInView="show"
+      viewport={{ once, amount: 0.2 }}
+    >
+      {children}
+    </MotionTag>
+  )
+}
+
+interface StaggerItemProps {
+  children: ReactNode
+  className?: string
+  as?: "div" | "li" | "span"
+}
+
+export function StaggerItem({ children, className, as = "div" }: StaggerItemProps) {
+  const reduce = useReducedMotion()
+  const MotionTag = motion[as]
+
+  if (reduce) {
+    const Tag = as
+    return <Tag className={className}>{children}</Tag>
+  }
+
+  return (
+    <MotionTag className={className} variants={STAGGER_ITEM}>
+      {children}
+    </MotionTag>
+  )
+}
+
+interface TiltCardProps {
+  children: ReactNode
+  className?: string
+  /** Max tilt in degrees at the edges. Default 10. */
+  intensity?: number
+  /** Lift toward the viewer on hover, in px. Default 24. */
+  lift?: number
+}
+
+/**
+ * 3D pointer tilt. The card rotates toward the cursor on hover and settles
+ * back when the pointer leaves — a lightweight "studio turntable" effect that
+ * works with any image (no 3D model required).
+ */
+export function TiltCard({ children, className, intensity = 10, lift = 24 }: TiltCardProps) {
+  const reduce = useReducedMotion()
+  const ref = useRef<HTMLDivElement>(null)
+
+  const mvX = useMotionValue(0.5)
+  const mvY = useMotionValue(0.5)
+
+  const springConfig = { stiffness: 150, damping: 18, mass: 0.4 }
+  const rotateX = useSpring(useTransform(mvY, [0, 1], [intensity, -intensity]), springConfig)
+  const rotateY = useSpring(useTransform(mvX, [0, 1], [-intensity, intensity]), springConfig)
+
+  function handlePointerMove(e: React.PointerEvent<HTMLDivElement>) {
+    const el = ref.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    mvX.set((e.clientX - rect.left) / rect.width)
+    mvY.set((e.clientY - rect.top) / rect.height)
+  }
+
+  function handlePointerLeave() {
+    mvX.set(0.5)
+    mvY.set(0.5)
+  }
+
+  if (reduce) {
+    return <div className={className}>{children}</div>
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={`perspective-1000 ${className ?? ""}`}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={handlePointerLeave}
+    >
+      <motion.div
+        className="preserve-3d"
+        style={{ rotateX, rotateY }}
+        whileHover={{ z: lift }}
+        transition={{ type: "spring", ...springConfig }}
+      >
+        {children}
+      </motion.div>
+    </div>
+  )
+}

--- a/components/newsletter.tsx
+++ b/components/newsletter.tsx
@@ -5,6 +5,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ArrowRight, Sparkles, Loader2 } from "lucide-react"
+import { Reveal } from "@/components/motion/motion-primitives"
 
 interface NewsletterProps {
   cms?: Record<string, any>
@@ -55,7 +56,7 @@ export function Newsletter({ cms = {} }: NewsletterProps) {
   return (
     <section className="py-12 lg:py-20 bg-pop-yellow">
       <div className="mx-auto max-w-7xl px-4 lg:px-6">
-        <div className="max-w-2xl mx-auto text-center">
+        <Reveal className="max-w-2xl mx-auto text-center">
           <span className="inline-block px-4 py-1 bg-foreground text-pop-yellow text-xs font-bold uppercase tracking-wider mb-4">
             {c.badge}
           </span>
@@ -109,7 +110,7 @@ export function Newsletter({ cms = {} }: NewsletterProps) {
           )}
 
           <p className="text-xs text-foreground/50 mt-5 uppercase tracking-wide">{c.disclaimer}</p>
-        </div>
+        </Reveal>
       </div>
     </section>
   )

--- a/components/product-card.tsx
+++ b/components/product-card.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 import { useState } from "react"
 import Link from "next/link"
+import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { Check, Plus, Star, Flame, Eye } from "lucide-react"
 import { type Product, formatPrice } from "@/lib/products"
@@ -39,7 +40,9 @@ export function ProductCard({ product }: ProductCardProps) {
     setShowQuickView(true)
   }
 
-  const hoverImage = product.images[1] || product.images[0]
+  const baseImage = product.images[0] || "/placeholder.svg"
+  const hoverImage = product.images[1] || product.images[0] || "/placeholder.svg"
+  const hasHoverImage = Boolean(product.images[1])
 
   const savingsPercent = product.originalPriceInCents
     ? Math.round(((product.originalPriceInCents - product.priceInCents) / product.originalPriceInCents) * 100)
@@ -50,118 +53,120 @@ export function ProductCard({ product }: ProductCardProps) {
 
   return (
     <>
-      <Link
-        href={`/product/${product.id}`}
-        className="group block"
+      <div
+        className="group relative"
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
-        {/* Image container */}
-        <div className="aspect-[4/5] overflow-hidden bg-secondary mb-3 relative rounded-lg">
-          {/* Base image */}
-          <img
-            src={product.images[0] || "/placeholder.svg"}
-            alt={product.name}
-            className={`absolute inset-0 w-full h-full object-cover transition-all duration-500 ${isHovered ? "opacity-0 scale-105" : "opacity-100 scale-100"
+        {/* Image card — navigation link wraps only the imagery (no nested buttons) */}
+        <div className="relative aspect-[4/5] overflow-hidden bg-secondary mb-3 rounded-xl border-2 border-transparent group-hover:border-foreground/10 transition-all duration-300 group-hover:shadow-[6px_6px_0_0_var(--foreground)]">
+          <Link
+            href={`/product/${product.id}`}
+            aria-label={`View ${product.name}`}
+            className="absolute inset-0 z-0 block"
+          >
+            <Image
+              src={baseImage}
+              alt={product.name}
+              fill
+              sizes="(max-width: 1024px) 50vw, 25vw"
+              className={`object-cover transition-all duration-500 ${
+                isHovered && hasHoverImage ? "opacity-0 scale-105" : "opacity-100 scale-100 group-hover:scale-105"
               }`}
-          />
+            />
+            {hasHoverImage && (
+              <Image
+                src={hoverImage}
+                alt=""
+                aria-hidden="true"
+                fill
+                sizes="(max-width: 1024px) 50vw, 25vw"
+                className={`object-cover transition-all duration-500 ${
+                  isHovered ? "opacity-100 scale-100" : "opacity-0 scale-110"
+                }`}
+              />
+            )}
+          </Link>
 
-          {/* Hover image */}
-          <img
-            src={hoverImage || "/placeholder.svg"}
-            alt={`${product.name} alternate view`}
-            className={`absolute inset-0 w-full h-full object-cover transition-all duration-500 ${isHovered ? "opacity-100 scale-100" : "opacity-0 scale-110"
-              }`}
-          />
-
-          <div className="absolute top-2 left-2 flex flex-col gap-1.5 z-10">
+          {/* Badges (non-interactive) */}
+          <div className="absolute top-2 left-2 flex flex-col gap-1.5 z-10 pointer-events-none">
             {product.isBestseller && (
-              <span className="bg-gradient-to-r from-pop-yellow to-pop-orange text-foreground text-[10px] lg:text-xs font-black px-2.5 py-1 uppercase tracking-wide shadow-md flex items-center gap-1">
+              <span className="bg-gradient-to-r from-pop-yellow to-pop-orange text-foreground text-[10px] lg:text-xs font-black px-2.5 py-1 rounded-full uppercase tracking-wide shadow-md flex items-center gap-1">
                 <Star className="h-3 w-3 fill-current" />
                 Bestseller
               </span>
             )}
 
             {product.isTrending && (
-              <span className="bg-gradient-to-r from-pop-pink to-pop-red text-white text-[10px] lg:text-xs font-black px-2.5 py-1 uppercase tracking-wide shadow-md flex items-center gap-1 animate-pulse">
+              <span className="bg-gradient-to-r from-pop-pink to-pop-red text-white text-[10px] lg:text-xs font-black px-2.5 py-1 rounded-full uppercase tracking-wide shadow-md flex items-center gap-1 animate-pulse">
                 <Flame className="h-3 w-3" />
                 Trending
               </span>
             )}
 
-            {/* Original badges */}
             {product.badge && !product.isBestseller && !product.isTrending && (
-              <span className="bg-pop-pink text-white text-[10px] lg:text-xs font-bold px-2.5 py-1 uppercase tracking-wide shadow-md">
+              <span className="bg-pop-pink text-white text-[10px] lg:text-xs font-bold px-2.5 py-1 rounded-full uppercase tracking-wide shadow-md">
                 {product.badge}
               </span>
             )}
 
             {product.condition === "Excellent" && (
-              <span className="bg-pop-teal text-white text-[10px] lg:text-xs font-bold px-2.5 py-1 uppercase tracking-wide shadow-md">
+              <span className="bg-pop-teal text-white text-[10px] lg:text-xs font-bold px-2.5 py-1 rounded-full uppercase tracking-wide shadow-md">
                 {product.condition}
               </span>
             )}
 
             {isLowStock && (
               <span
-                className={`${isVeryLowStock ? "bg-pop-red animate-pulse" : "bg-pop-orange"} text-white text-[10px] lg:text-xs font-black px-2.5 py-1 uppercase tracking-wide shadow-md`}
+                className={`${isVeryLowStock ? "bg-pop-red animate-pulse" : "bg-pop-orange"} text-white text-[10px] lg:text-xs font-black px-2.5 py-1 rounded-full uppercase tracking-wide shadow-md`}
               >
                 Only {product.stockCount} left!
               </span>
             )}
 
             {savingsPercent >= 15 && (
-              <span className="bg-gradient-to-r from-pop-red to-pop-pink text-white text-[10px] lg:text-xs font-black px-2.5 py-1 uppercase tracking-wide shadow-md">
+              <span className="bg-gradient-to-r from-pop-red to-pop-pink text-white text-[10px] lg:text-xs font-black px-2.5 py-1 rounded-full uppercase tracking-wide shadow-md">
                 Save {savingsPercent}%
               </span>
             )}
           </div>
 
-          {/* Wishlist button */}
-          <div
-            className={`absolute bottom-2 left-2 transition-all duration-300 z-10 ${isHovered ? "opacity-100" : "opacity-0"}`}
-          >
+          {/* Action buttons — siblings of the link, always tappable on touch,
+              revealed on hover for pointer devices. */}
+          <div className="absolute bottom-2 left-2 flex gap-1.5 z-20 transition-all duration-300 opacity-100 translate-y-0 lg:opacity-0 lg:translate-y-2 lg:group-hover:opacity-100 lg:group-hover:translate-y-0">
             <WishlistButton
               productId={product.id}
               size="icon"
               variant="ghost"
-              className="h-9 w-9 bg-white/90 hover:bg-white shadow-md"
+              className="h-11 w-11 bg-white/90 hover:bg-white shadow-md cursor-pointer"
             />
-          </div>
-
-          {/* Quick View button */}
-          <div
-            className={`absolute bottom-2 left-12 transition-all duration-300 z-10 ${isHovered ? "opacity-100" : "opacity-0"
-              }`}
-          >
             <Button
               size="icon"
               variant="ghost"
-              className="h-9 w-9 bg-white/90 hover:bg-white shadow-md"
+              className="h-11 w-11 bg-white/90 hover:bg-white shadow-md cursor-pointer"
               onClick={handleQuickView}
+              aria-label={`Quick view ${product.name}`}
             >
               <Eye className="h-4 w-4" />
             </Button>
           </div>
 
-          {/* Quick add button */}
-          <div
-            className={`absolute bottom-2 right-2 transition-all duration-300 z-10 ${isHovered ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
-              }`}
-          >
+          <div className="absolute bottom-2 right-2 z-20 transition-all duration-300 opacity-100 translate-y-0 lg:opacity-0 lg:translate-y-2 lg:group-hover:opacity-100 lg:group-hover:translate-y-0">
             <Button
               size="icon"
-              className={`h-10 w-10 shadow-lg transition-all ${justAdded ? "bg-pop-green hover:bg-pop-green" : "bg-foreground hover:bg-foreground/90"
-                }`}
+              className={`h-11 w-11 shadow-lg cursor-pointer transition-all ${
+                justAdded ? "bg-pop-green hover:bg-pop-green" : "bg-foreground hover:bg-foreground/90"
+              }`}
               onClick={handleAddToCart}
+              aria-label={justAdded ? "Added to cart" : `Add ${product.name} to cart`}
             >
               {justAdded ? <Check className="h-4 w-4 text-white" /> : <Plus className="h-4 w-4 text-background" />}
             </Button>
           </div>
         </div>
 
-        {/* Product info */}
-        <div className="space-y-1.5">
+        {/* Product info — its own link (no nesting with the buttons above) */}
+        <Link href={`/product/${product.id}`} className="block space-y-1.5">
           <div className="flex items-center justify-between">
             <span className="font-mono text-[10px] lg:text-xs text-muted-foreground uppercase tracking-wide">
               {[product.brand, product.year].filter(Boolean).join(" · ")}
@@ -196,8 +201,8 @@ export function ProductCard({ product }: ProductCardProps) {
               {isVeryLowStock ? "Last one available" : `Only ${product.stockCount} in stock`}
             </p>
           )}
-        </div>
-      </Link>
+        </Link>
+      </div>
 
       <UpsellDrawer open={showUpsell} onClose={() => setShowUpsell(false)} addedProduct={product} />
       <QuickViewModal product={product} open={showQuickView} onClose={() => setShowQuickView(false)} />

--- a/components/testimonials-section.tsx
+++ b/components/testimonials-section.tsx
@@ -1,4 +1,6 @@
+import Image from "next/image"
 import { Star } from "lucide-react"
+import { Reveal, Stagger, StaggerItem } from "@/components/motion/motion-primitives"
 
 interface TestimonialsSectionProps {
   cms?: Record<string, any>
@@ -42,55 +44,58 @@ export function TestimonialsSection({ cms = {} }: TestimonialsSectionProps) {
   return (
     <section className="py-16 lg:py-24 bg-secondary/30">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="text-center mb-12">
-          <h2 className="text-3xl lg:text-4xl font-bold tracking-tight mb-4">{heading}</h2>
-          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            {subtitle}
-          </p>
-        </div>
-
-        <div className="grid md:grid-cols-3 gap-6 lg:gap-8">
-          {testimonials.map((testimonial: any, index: number) => (
-            <div
-              key={index}
-              className="bg-background p-6 lg:p-8 rounded-2xl border-2 border-border hover:border-accent/50 transition-colors"
-            >
-              <div className="flex items-center gap-0.5 mb-4">
-                {[...Array(testimonial.rating || 5)].map((_, i) => (
-                  <Star key={i} className="h-4 w-4 fill-pop-yellow text-pop-yellow" />
-                ))}
-              </div>
-
-              <p className="text-muted-foreground mb-6 leading-relaxed">"{testimonial.text}"</p>
-
-              <div className="flex items-center gap-3">
-                <div className="w-12 h-12 rounded-full bg-secondary overflow-hidden">
-                  <img
-                    src={testimonial.image || "/placeholder.svg"}
-                    alt={testimonial.name}
-                    className="w-full h-full object-cover"
-                  />
-                </div>
-                <div>
-                  <p className="font-bold text-sm">{testimonial.name}</p>
-                  <p className="text-xs text-muted-foreground">{testimonial.location}</p>
-                </div>
-              </div>
-
-              <div className="mt-4 pt-4 border-t border-border">
-                <p className="text-xs text-muted-foreground">Verified Purchase</p>
-                <p className="text-sm font-medium mt-1">{testimonial.product}</p>
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <div className="text-center mt-12">
-          <div className="inline-flex items-center gap-2 bg-pop-yellow px-6 py-3 rounded-full">
-            <Star className="h-5 w-5 fill-foreground text-foreground" />
-            <span className="font-bold">Top-rated store for vintage tech</span>
+        <Reveal>
+          <div className="text-center mb-12">
+            <h2 className="text-3xl lg:text-4xl font-black uppercase tracking-tight mb-4">{heading}</h2>
+            <p className="text-lg text-muted-foreground max-w-2xl mx-auto">{subtitle}</p>
           </div>
-        </div>
+        </Reveal>
+
+        <Stagger className="grid md:grid-cols-3 gap-6 lg:gap-8">
+          {testimonials.map((testimonial: any, index: number) => (
+            <StaggerItem key={index}>
+              <div className="h-full bg-background p-6 lg:p-8 rounded-2xl border-2 border-border hover:border-pop-pink/50 hover:-translate-y-1 transition-all duration-300">
+                <div className="flex items-center gap-0.5 mb-4">
+                  {[...Array(testimonial.rating || 5)].map((_, i) => (
+                    <Star key={i} className="h-4 w-4 fill-pop-yellow text-pop-yellow" />
+                  ))}
+                </div>
+
+                <p className="text-muted-foreground mb-6 leading-relaxed">"{testimonial.text}"</p>
+
+                <div className="flex items-center gap-3">
+                  <div className="relative w-12 h-12 rounded-full bg-secondary overflow-hidden">
+                    <Image
+                      src={testimonial.image || "/placeholder.svg"}
+                      alt={testimonial.name}
+                      fill
+                      sizes="48px"
+                      className="object-cover"
+                    />
+                  </div>
+                  <div>
+                    <p className="font-bold text-sm">{testimonial.name}</p>
+                    <p className="text-xs text-muted-foreground">{testimonial.location}</p>
+                  </div>
+                </div>
+
+                <div className="mt-4 pt-4 border-t border-border">
+                  <p className="text-xs text-muted-foreground">Verified Purchase</p>
+                  <p className="text-sm font-medium mt-1">{testimonial.product}</p>
+                </div>
+              </div>
+            </StaggerItem>
+          ))}
+        </Stagger>
+
+        <Reveal delay={0.1}>
+          <div className="text-center mt-12">
+            <div className="inline-flex items-center gap-2 bg-pop-yellow px-6 py-3 rounded-full">
+              <Star className="h-5 w-5 fill-foreground text-foreground" />
+              <span className="font-bold">Top-rated store for vintage tech</span>
+            </div>
+          </div>
+        </Reveal>
       </div>
     </section>
   )

--- a/lib/stripe-products.ts
+++ b/lib/stripe-products.ts
@@ -3,8 +3,20 @@ import Stripe from "stripe"
 import type { Product } from "./products"
 import { extractProductInfo } from "./product-fallback"
 
-// Initialize Stripe client
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!)
+// Lazily initialize the Stripe client. Returns null when STRIPE_SECRET_KEY is
+// missing (e.g. local/preview without env) so callers degrade gracefully to an
+// empty catalog instead of crashing at module-load time.
+let _stripe: Stripe | null = null
+function getStripe(): Stripe | null {
+    if (_stripe) return _stripe
+    const key = process.env.STRIPE_SECRET_KEY
+    if (!key) {
+        console.warn("[Stripe Products] STRIPE_SECRET_KEY is not set — returning empty data")
+        return null
+    }
+    _stripe = new Stripe(key)
+    return _stripe
+}
 
 /**
  * Transform Stripe product/price into our Product format
@@ -71,6 +83,8 @@ export async function getStripeProducts(options?: {
     featured?: boolean
 }): Promise<Product[]> {
     try {
+        const stripe = getStripe()
+        if (!stripe) return []
         // Fetch all active products
         const products = await stripe.products.list({
             active: true,
@@ -108,6 +122,8 @@ export async function getStripeProducts(options?: {
  */
 export async function getStripeProductById(productId: string): Promise<Product | null> {
     try {
+        const stripe = getStripe()
+        if (!stripe) return null
         const product = await stripe.products.retrieve(productId, {
             expand: ["default_price"],
         })
@@ -130,6 +146,8 @@ export async function getStripeProductById(productId: string): Promise<Product |
  */
 export async function getProductInventory(productId: string): Promise<number | null> {
     try {
+        const stripe = getStripe()
+        if (!stripe) return null
         const product = await stripe.products.retrieve(productId)
         const stockCount = product.metadata?.stockCount
         return stockCount ? parseInt(stockCount, 10) : null
@@ -144,6 +162,8 @@ export async function getProductInventory(productId: string): Promise<number | n
  */
 export async function searchStripeProducts(query: string): Promise<Product[]> {
     try {
+        const stripe = getStripe()
+        if (!stripe) return []
         const products = await stripe.products.search({
             query: `active:'true' AND (name~'${query}' OR description~'${query}')`,
             expand: ["data.default_price"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@stripe/react-stripe-js": "5.4.1",
         "@stripe/stripe-js": "8.6.0",
         "@supabase/ssr": "0.8.0",
-        "@supabase/supabase-js": "*",
+        "@supabase/supabase-js": "latest",
         "@vercel/analytics": "1.3.1",
         "autoprefixer": "^10.4.20",
         "class-variance-authority": "^0.7.1",
@@ -51,6 +51,7 @@
         "embla-carousel-react": "8.5.1",
         "input-otp": "1.4.1",
         "lucide-react": "^0.454.0",
+        "motion": "^12.40.0",
         "next": "16.0.10",
         "next-themes": "^0.4.6",
         "react": "19.2.0",
@@ -2817,7 +2818,7 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2827,7 +2828,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -3800,6 +3801,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4264,6 +4292,47 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.40.0.tgz",
+      "integrity": "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.40.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -4409,6 +4478,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4954,6 +5024,7 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "embla-carousel-react": "8.5.1",
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",
+    "motion": "^12.40.0",
     "next": "16.0.10",
     "next-themes": "^0.4.6",
     "react": "19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,10 +106,10 @@ importers:
         version: 8.6.0
       '@supabase/ssr':
         specifier: 0.8.0
-        version: 0.8.0(@supabase/supabase-js@2.103.0)
+        version: 0.8.0(@supabase/supabase-js@2.108.2)
       '@supabase/supabase-js':
         specifier: latest
-        version: 2.103.0
+        version: 2.108.2
       '@vercel/analytics':
         specifier: 1.3.1
         version: 1.3.1(next@16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
@@ -137,6 +137,9 @@ importers:
       lucide-react:
         specifier: ^0.454.0
         version: 0.454.0(react@19.2.0)
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next:
         specifier: 16.0.10
         version: 16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1304,23 +1307,23 @@ packages:
     resolution: {integrity: sha512-EB0/GGgs4hfezzkiMkinlRgWtjz8fSdwVQhwYS7Sg/RQrSvuNOz+ssPjD+lAzqaYTCB0zlbrt0fcqVziLJrufQ==}
     engines: {node: '>=12.16'}
 
-  '@supabase/auth-js@2.103.0':
-    resolution: {integrity: sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A==}
+  '@supabase/auth-js@2.108.2':
+    resolution: {integrity: sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/functions-js@2.103.0':
-    resolution: {integrity: sha512-YrneV2NjskUkkmkZ2Jt2n3elBgbWzV4Y1M9MM370z2Zd5ZPFqFbY8KIoPwuNjtAGE9YrpKBxnbZqeF07BiN9Og==}
+  '@supabase/functions-js@2.108.2':
+    resolution: {integrity: sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/phoenix@0.4.0':
-    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+  '@supabase/phoenix@0.4.2':
+    resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
 
-  '@supabase/postgrest-js@2.103.0':
-    resolution: {integrity: sha512-rC3sRxYdPZymkp2CZR1MiNQgbOleD01bGsW8VxEKRR5nMkLZ1NgAS1QTQf78Wh30czFyk505ZYr9Od8/mWT2TA==}
+  '@supabase/postgrest-js@2.108.2':
+    resolution: {integrity: sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/realtime-js@2.103.0':
-    resolution: {integrity: sha512-gcPtXzZ6izyyBVf2of7K3dEt8CScPJn8VcSlQq6oWL9QoE1kqfQl0oFrOMHd5qrcADewxI7OxxosLB8W4XqtIQ==}
+  '@supabase/realtime-js@2.108.2':
+    resolution: {integrity: sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==}
     engines: {node: '>=20.0.0'}
 
   '@supabase/ssr@0.8.0':
@@ -1328,12 +1331,12 @@ packages:
     peerDependencies:
       '@supabase/supabase-js': ^2.76.1
 
-  '@supabase/storage-js@2.103.0':
-    resolution: {integrity: sha512-DHmlvdAXwtOmZNbkIZi4lkobPR3XjIzoOgzoz5duMf6G+sDeY015YrzMJCnqdccuYr7X5x4yYuSwF//RoN2dvQ==}
+  '@supabase/storage-js@2.108.2':
+    resolution: {integrity: sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/supabase-js@2.103.0':
-    resolution: {integrity: sha512-j/6q5+LtXbR/YOLSLhy7Na74RD1cV2v+KwIIuuqMEjk1JpLEEyu0ynwDHpGoxMncDQl+R5FogaVqZm+85lZvtw==}
+  '@supabase/supabase-js@2.108.2':
+    resolution: {integrity: sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==}
     engines: {node: '>=20.0.0'}
 
   '@swc/helpers@0.5.15':
@@ -1464,9 +1467,6 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
-
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vercel/analytics@1.3.1':
     resolution: {integrity: sha512-xhSlYgAuJ6Q4WQGkzYTLmXwhYl39sWjoMA3nHxfkvG+WdBT25c563a7QhwwKivEOZtPJXifYHR1m2ihoisbWyA==}
@@ -1657,6 +1657,20 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  framer-motion@12.40.0:
+    resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -1803,6 +1817,26 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  motion-dom@12.40.0:
+    resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
+  motion@12.40.0:
+    resolution: {integrity: sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1952,6 +1986,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2107,6 +2142,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vaul@1.1.2:
@@ -2117,18 +2153,6 @@ packages:
 
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -3186,50 +3210,42 @@ snapshots:
 
   '@stripe/stripe-js@8.6.0': {}
 
-  '@supabase/auth-js@2.103.0':
+  '@supabase/auth-js@2.108.2':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/functions-js@2.103.0':
+  '@supabase/functions-js@2.108.2':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/phoenix@0.4.0': {}
+  '@supabase/phoenix@0.4.2': {}
 
-  '@supabase/postgrest-js@2.103.0':
+  '@supabase/postgrest-js@2.108.2':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/realtime-js@2.103.0':
+  '@supabase/realtime-js@2.108.2':
     dependencies:
-      '@supabase/phoenix': 0.4.0
-      '@types/ws': 8.18.1
+      '@supabase/phoenix': 0.4.2
       tslib: 2.8.1
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
-  '@supabase/ssr@0.8.0(@supabase/supabase-js@2.103.0)':
+  '@supabase/ssr@0.8.0(@supabase/supabase-js@2.108.2)':
     dependencies:
-      '@supabase/supabase-js': 2.103.0
+      '@supabase/supabase-js': 2.108.2
       cookie: 1.1.1
 
-  '@supabase/storage-js@2.103.0':
+  '@supabase/storage-js@2.108.2':
     dependencies:
       iceberg-js: 0.8.1
       tslib: 2.8.1
 
-  '@supabase/supabase-js@2.103.0':
+  '@supabase/supabase-js@2.108.2':
     dependencies:
-      '@supabase/auth-js': 2.103.0
-      '@supabase/functions-js': 2.103.0
-      '@supabase/postgrest-js': 2.103.0
-      '@supabase/realtime-js': 2.103.0
-      '@supabase/storage-js': 2.103.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
+      '@supabase/auth-js': 2.108.2
+      '@supabase/functions-js': 2.108.2
+      '@supabase/postgrest-js': 2.108.2
+      '@supabase/realtime-js': 2.108.2
+      '@supabase/storage-js': 2.108.2
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3339,10 +3355,6 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
-
-  '@types/ws@8.18.1':
-    dependencies:
-      '@types/node': 22.19.17
 
   '@vercel/analytics@1.3.1(next@16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -3510,6 +3522,15 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  framer-motion@12.40.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      motion-dom: 12.40.0
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
   function-bind@1.1.2: {}
 
   get-intrinsic@1.3.0:
@@ -3623,6 +3644,20 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  motion-dom@12.40.0:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
+
+  motion@12.40.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      framer-motion: 12.40.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   nanoid@3.3.11: {}
 
@@ -3956,7 +3991,5 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
-
-  ws@8.20.0: {}
 
   zod@3.25.76: {}


### PR DESCRIPTION
Add Framer Motion (motion v12) and rebuild the storefront experience.

Hero & motion
- Rebuild hero: split layout with a pointer-tilt 3D showcase camera, scroll parallax, spotlight glow, floating chips, staggered entrance.
- New reusable, reduced-motion-aware primitives (Reveal/Stagger/TiltCard) in components/motion/motion-primitives.tsx.
- globals.css: add missing --pop-red token (fixes invisible Trending/ low-stock/savings badges), spotlight + 3D helpers, and a global prefers-reduced-motion block.

Accessibility & interaction
- product-card: remove invalid nested <button> inside <a> (separate image/info links, buttons as siblings); 44px touch targets; product actions now tappable on touch, not hover-only.

Performance
- Migrate product-card, animated-categories, testimonials to next/image.
- Fetch products server-side on the homepage and pass to FeaturedProducts/AnimatedCategories (removes client fetch waterfalls, spinners, and layout shift).
- lib/stripe-products: lazy Stripe client so a missing STRIPE_SECRET_KEY degrades to an empty catalog instead of crashing at module load.

Header & shop
- Header: robust grid-centered logo, real expanding search (-> /shop?q=), render admin link for admins.
- Shop: seed filters from ?q/?search/?brand/?sort params; brand filter uses the brand field; staggered grid reveal.

Site-wide motion reveals across featured products, brand categories, testimonials, and newsletter.