### PR TITLE
feat(images): enable image optimization + clean product-card presenta…

### DIFF
--- a/components/product-card.tsx
+++ b/components/product-card.tsx
@@ -59,33 +59,41 @@ export function ProductCard({ product }: ProductCardProps) {
         onMouseLeave={() => setIsHovered(false)}
       >
         {/* Image card — navigation link wraps only the imagery (no nested buttons) */}
-        <div className="relative aspect-[4/5] overflow-hidden bg-secondary mb-3 rounded-xl border-2 border-transparent group-hover:border-foreground/10 transition-all duration-300 group-hover:shadow-[6px_6px_0_0_var(--foreground)]">
+        <div className="relative aspect-[4/5] overflow-hidden bg-white mb-3 rounded-xl border-2 border-transparent group-hover:border-foreground/10 transition-all duration-300 group-hover:shadow-[6px_6px_0_0_var(--foreground)]">
           <Link
             href={`/product/${product.id}`}
             aria-label={`View ${product.name}`}
             className="absolute inset-0 z-0 block"
           >
-            <Image
-              src={baseImage}
-              alt={product.name}
-              fill
-              sizes="(max-width: 1024px) 50vw, 25vw"
-              className={`object-cover transition-all duration-500 ${
-                isHovered && hasHoverImage ? "opacity-0 scale-105" : "opacity-100 scale-100 group-hover:scale-105"
-              }`}
-            />
-            {hasHoverImage && (
+            {/* Padded inner area so the full camera is presented cleanly
+                (object-contain) with breathing room, like a product catalog. */}
+            <div className="absolute inset-4 lg:inset-6">
               <Image
-                src={hoverImage}
-                alt=""
-                aria-hidden="true"
+                src={baseImage}
+                alt={product.name}
                 fill
                 sizes="(max-width: 1024px) 50vw, 25vw"
-                className={`object-cover transition-all duration-500 ${
-                  isHovered ? "opacity-100 scale-100" : "opacity-0 scale-110"
+                className={`object-contain transition-all duration-500 ${
+                  hasHoverImage
+                    ? isHovered
+                      ? "opacity-0"
+                      : "opacity-100"
+                    : "opacity-100 group-hover:scale-105"
                 }`}
               />
-            )}
+              {hasHoverImage && (
+                <Image
+                  src={hoverImage}
+                  alt=""
+                  aria-hidden="true"
+                  fill
+                  sizes="(max-width: 1024px) 50vw, 25vw"
+                  className={`object-contain transition-opacity duration-500 ${
+                    isHovered ? "opacity-100" : "opacity-0"
+                  }`}
+                />
+              )}
+            </div>
           </Link>
 
           {/* Badges (non-interactive) */}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -64,7 +64,11 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
-    unoptimized: true,
+    // Optimize images (WebP/AVIF, srcset, lazy). Product photos are served
+    // from Stripe; local /public images need no remote pattern.
+    remotePatterns: [
+      { protocol: "https", hostname: "files.stripe.com" },
+    ],
   },
   async headers() {
     return [


### PR DESCRIPTION
…tion

- next.config.mjs: turn on Next image optimization (remove unoptimized), allowlist files.stripe.com (verified product-image host) via remotePatterns. Verified: /_next/image serves WebP for Stripe + local images, rejects non-allowlisted hosts (400).
- product-card: present the full camera cleanly with object-contain on a padded white tile (clean aspect ratio, like a product catalog) instead of cropping with object-cover; hover now crossfades to the alternate-angle photo (images[1]) with no zoom — the "angle change" effect. Single-image products keep a subtle hover zoom as feedback.