### PR TITLE
fix(shop): products invisible from stagger gate; theme-aware tiles; m…

### DIFF
--- a/app/shop/page.tsx
+++ b/app/shop/page.tsx
@@ -162,9 +162,15 @@ function ShopContent() {
 
         {/* Page header */}
         <div className="mb-10">
-          <span className="font-mono text-xs text-accent tracking-wide uppercase">Collection</span>
-          <h1 className="text-3xl lg:text-4xl font-bold mt-2 tracking-tight">Shop</h1>
-          <p className="text-muted-foreground mt-2">Browse our curated collection of Y2K cameras and accessories</p>
+          <span className="inline-block px-3 py-1 bg-pop-pink text-white text-xs font-bold uppercase tracking-wider rounded-full mb-3">
+            Collection
+          </span>
+          <h1 className="text-4xl lg:text-6xl font-black uppercase tracking-tight leading-[0.9]">
+            Shop <span className="text-pop-pink">Y2K</span>
+          </h1>
+          <p className="text-muted-foreground mt-3 text-base lg:text-lg max-w-xl">
+            Browse our curated collection of Y2K cameras and accessories — tested, cleaned, and ready to shoot.
+          </p>
         </div>
 
         {/* Featured/Trending section for social proof */}
@@ -230,7 +236,8 @@ function ShopContent() {
                 {selectedCategory !== "accessory" && (
                   <>
                     <Select value={selectedBrand} onValueChange={setSelectedBrand}>
-                      <SelectTrigger className="w-[140px] h-12 rounded-xl bg-secondary border-0">
+                      <SelectTrigger className="w-[150px] h-12 rounded-xl bg-secondary border-0">
+                        <span className="text-muted-foreground text-xs font-semibold uppercase tracking-wide mr-1.5">Brand</span>
                         <SelectValue placeholder="Brand" />
                       </SelectTrigger>
                       <SelectContent>
@@ -243,7 +250,8 @@ function ShopContent() {
                     </Select>
 
                     <Select value={selectedYear} onValueChange={setSelectedYear}>
-                      <SelectTrigger className="w-[120px] h-12 rounded-xl bg-secondary border-0">
+                      <SelectTrigger className="w-[130px] h-12 rounded-xl bg-secondary border-0">
+                        <span className="text-muted-foreground text-xs font-semibold uppercase tracking-wide mr-1.5">Year</span>
                         <SelectValue placeholder="Year" />
                       </SelectTrigger>
                       <SelectContent>
@@ -259,7 +267,8 @@ function ShopContent() {
 
                 {selectedCategory === "accessory" && (
                   <Select value={selectedSubcategory} onValueChange={setSelectedSubcategory}>
-                    <SelectTrigger className="w-[150px] h-12 rounded-xl bg-secondary border-0">
+                    <SelectTrigger className="w-[160px] h-12 rounded-xl bg-secondary border-0 capitalize">
+                      <span className="text-muted-foreground text-xs font-semibold uppercase tracking-wide mr-1.5">Type</span>
                       <SelectValue placeholder="Type" />
                     </SelectTrigger>
                     <SelectContent>
@@ -273,7 +282,8 @@ function ShopContent() {
                 )}
 
                 <Select value={sortBy} onValueChange={setSortBy}>
-                  <SelectTrigger className="w-[160px] h-12 rounded-xl bg-secondary border-0">
+                  <SelectTrigger className="w-[180px] h-12 rounded-xl bg-secondary border-0">
+                    <span className="text-muted-foreground text-xs font-semibold uppercase tracking-wide mr-1.5">Sort</span>
                     <SelectValue placeholder="Sort by" />
                   </SelectTrigger>
                   <SelectContent>
@@ -373,7 +383,7 @@ function ShopContent() {
 
         {/* Product grid */}
         {filteredProducts.length > 0 ? (
-          <Stagger className={`grid grid-cols-2 gap-5 lg:gap-8 ${gridCols === 3 ? "lg:grid-cols-3" : "lg:grid-cols-4"}`}>
+          <Stagger inView={false} className={`grid grid-cols-2 gap-5 lg:gap-8 ${gridCols === 3 ? "lg:grid-cols-3" : "lg:grid-cols-4"}`}>
             {filteredProducts.map((product) => (
               <StaggerItem key={product.id}>
                 <ProductCard product={product} />

--- a/components/motion/motion-primitives.tsx
+++ b/components/motion/motion-primitives.tsx
@@ -108,9 +108,16 @@ interface StaggerProps {
   className?: string
   once?: boolean
   as?: "div" | "section" | "ul"
+  /**
+   * When true (default) the stagger plays as the container scrolls into view.
+   * When false it plays immediately on mount — use this for primary content
+   * (e.g. a tall product grid) so items can never get stuck hidden if the
+   * container is larger than the viewport.
+   */
+  inView?: boolean
 }
 
-export function Stagger({ children, className, once = true, as = "div" }: StaggerProps) {
+export function Stagger({ children, className, once = true, as = "div", inView = true }: StaggerProps) {
   const reduce = useReducedMotion()
   const MotionTag = motion[as]
 
@@ -119,14 +126,14 @@ export function Stagger({ children, className, once = true, as = "div" }: Stagge
     return <Tag className={className}>{children}</Tag>
   }
 
+  // amount: 0 → trigger as soon as any part intersects, robust for containers
+  // taller than the viewport.
+  const trigger = inView
+    ? { whileInView: "show" as const, viewport: { once, amount: 0 } }
+    : { animate: "show" as const }
+
   return (
-    <MotionTag
-      className={className}
-      variants={STAGGER_CONTAINER}
-      initial="hidden"
-      whileInView="show"
-      viewport={{ once, amount: 0.2 }}
-    >
+    <MotionTag className={className} variants={STAGGER_CONTAINER} initial="hidden" {...trigger}>
       {children}
     </MotionTag>
   )

--- a/components/product-card.tsx
+++ b/components/product-card.tsx
@@ -59,7 +59,7 @@ export function ProductCard({ product }: ProductCardProps) {
         onMouseLeave={() => setIsHovered(false)}
       >
         {/* Image card — navigation link wraps only the imagery (no nested buttons) */}
-        <div className="relative aspect-[4/5] overflow-hidden bg-white mb-3 rounded-xl border-2 border-transparent group-hover:border-foreground/10 transition-all duration-300 group-hover:shadow-[6px_6px_0_0_var(--foreground)]">
+        <div className="relative aspect-[4/5] overflow-hidden bg-card mb-3 rounded-xl border-2 border-border/60 group-hover:border-foreground/20 transition-all duration-300 group-hover:shadow-[6px_6px_0_0_var(--foreground)]">
           <Link
             href={`/product/${product.id}`}
             aria-label={`View ${product.name}`}


### PR DESCRIPTION
…enu labels

- motion: Stagger gated the whole grid behind whileInView with amount 0.2. A product grid is taller than the viewport, so 20% was never visible and cards stayed at opacity:0 (products invisible despite the count). Fix: use amount:0 (trigger on first intersection) and add an `inView` prop; the shop grid now animates on mount (inView={false}) so primary content can never get stuck hidden.
- product-card: theme-aware tile (bg-card → white in light, dark in dark) with a subtle border so white tiles read cleanly on the cream background.
- shop: label the filter menus (Brand / Year / Type / Sort) so they're not ambiguous "All / All / Featured"; bolder branded page heading.