### PR TITLE
fix(hero): clean dot texture + neater camera animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -288,16 +288,11 @@ html {
   animation: float 4s ease-in-out infinite;
 }
 
-/* Advanced tech-inspired dot and grid pattern */
+/* Subtle dot texture — faint dots only (no grid lines), never crosses text */
 .bg-dot-pattern {
-  background-image:
-    radial-gradient(var(--foreground) 1px, transparent 1px),
-    linear-gradient(to right, oklch(0.15 0.02 45 / 0.03) 1px, transparent 1px),
-    linear-gradient(to bottom, oklch(0.15 0.02 45 / 0.03) 1px, transparent 1px);
-  background-size: 24px 24px, 48px 48px, 48px 48px;
+  background-image: radial-gradient(oklch(0.15 0.02 45 / 0.07) 1.2px, transparent 1.2px);
+  background-size: 22px 22px;
   background-position: 0 0;
-  opacity: 0.8;
-  /* Higher opacity since patterns are subtle */
 }
 
 /* Diagonal stripes pattern */

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -5,7 +5,7 @@ import Link from "next/link"
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { ArrowRight, Sparkles, Star, ShieldCheck } from "lucide-react"
-import { motion, useReducedMotion, useScroll, useTransform, useMotionValue, useSpring } from "motion/react"
+import { motion, useReducedMotion, useScroll, useTransform } from "motion/react"
 
 interface HeroProps {
   cms?: Record<string, any>
@@ -34,40 +34,19 @@ export function Hero({ cms = {} }: HeroProps) {
   const reduce = useReducedMotion()
   const sectionRef = useRef<HTMLElement>(null)
 
+  // Gentle scroll parallax (no skew — keeps the card crisp)
   const { scrollYProgress } = useScroll({ target: sectionRef, offset: ["start start", "end start"] })
-  const yImage = useTransform(scrollYProgress, [0, 1], [0, reduce ? 0 : -70])
-  const yCopy = useTransform(scrollYProgress, [0, 1], [0, reduce ? 0 : 50])
-  const yPillA = useTransform(scrollYProgress, [0, 1], [0, reduce ? 0 : -110])
-  const yPillB = useTransform(scrollYProgress, [0, 1], [0, reduce ? 0 : 90])
-
-  // pointer tilt
-  const px = useMotionValue(0.5)
-  const py = useMotionValue(0.5)
-  const spring = { stiffness: 120, damping: 18, mass: 0.5 }
-  const rotateY = useSpring(useTransform(px, [0, 1], [reduce ? 0 : -10, reduce ? 0 : 10]), spring)
-  const rotateX = useSpring(useTransform(py, [0, 1], [reduce ? 0 : 8, reduce ? 0 : -8]), spring)
-
-  function handlePointerMove(e: React.PointerEvent<HTMLElement>) {
-    if (reduce) return
-    const r = e.currentTarget.getBoundingClientRect()
-    px.set((e.clientX - r.left) / r.width)
-    py.set((e.clientY - r.top) / r.height)
-  }
-  function handlePointerLeave() {
-    px.set(0.5)
-    py.set(0.5)
-  }
+  const yImage = useTransform(scrollYProgress, [0, 1], [0, reduce ? 0 : -56])
+  const yCopy = useTransform(scrollYProgress, [0, 1], [0, reduce ? 0 : 44])
+  const yPillA = useTransform(scrollYProgress, [0, 1], [0, reduce ? 0 : -40])
+  const yPillB = useTransform(scrollYProgress, [0, 1], [0, reduce ? 0 : 40])
 
   return (
     <section ref={sectionRef} className="relative overflow-hidden bg-background border-b-2 border-foreground">
-      {/* dot-grid texture */}
-      <div className="pointer-events-none absolute inset-0 bg-dot-pattern opacity-60" aria-hidden="true" />
+      {/* faint dot texture */}
+      <div className="pointer-events-none absolute inset-0 bg-dot-pattern" aria-hidden="true" />
 
-      <div
-        onPointerMove={handlePointerMove}
-        onPointerLeave={handlePointerLeave}
-        className="relative mx-auto grid w-full max-w-[1400px] items-center gap-10 px-5 py-14 lg:grid-cols-12 lg:gap-10 lg:px-8 lg:py-20"
-      >
+      <div className="relative mx-auto grid w-full max-w-[1400px] items-center gap-12 px-5 py-16 lg:grid-cols-12 lg:gap-12 lg:px-8 lg:py-24">
         {/* Copy */}
         <motion.div
           className="z-10 lg:col-span-6 text-center lg:text-left"
@@ -86,7 +65,7 @@ export function Hero({ cms = {} }: HeroProps) {
 
           <motion.h1
             variants={reduce ? undefined : item}
-            className="font-display font-extrabold uppercase leading-[0.88] tracking-[-0.02em] text-foreground text-[clamp(3rem,8vw,6.5rem)]"
+            className="font-display font-extrabold uppercase leading-[0.9] tracking-[-0.02em] text-foreground text-[clamp(2.75rem,6.5vw,5.5rem)]"
           >
             <span className="block">{c.heading_line1}</span>
             <span className="block text-pop-pink">{c.heading_line2}</span>
@@ -137,17 +116,19 @@ export function Hero({ cms = {} }: HeroProps) {
           </motion.div>
         </motion.div>
 
-        {/* Camera card */}
-        <div className="lg:col-span-6 relative" style={{ perspective: 1200 }}>
-          <motion.div style={{ y: yImage }}>
+        {/* Camera card — clean rectangle, gentle float (no tilt/skew) */}
+        <div className="lg:col-span-6">
+          <motion.div style={{ y: yImage }} className="relative mx-auto w-full max-w-md">
             <motion.div
-              initial={reduce ? undefined : { opacity: 0, scale: 0.94, rotate: -1 }}
-              animate={reduce ? undefined : { opacity: 1, scale: 1, rotate: 0 }}
+              initial={reduce ? undefined : { opacity: 0, y: 24, scale: 0.96 }}
+              animate={reduce ? undefined : { opacity: 1, y: 0, scale: 1 }}
               transition={{ duration: 0.8, ease, delay: 0.15 }}
-              style={{ rotateX, rotateY, transformPerspective: 1200, transformStyle: "preserve-3d" }}
-              className="relative mx-auto max-w-md"
             >
-              <div className="relative aspect-square overflow-hidden rounded-2xl border-2 border-foreground bg-card shadow-[10px_10px_0_0_var(--foreground)]">
+              <motion.div
+                animate={reduce ? undefined : { y: [0, -10, 0] }}
+                transition={{ duration: 5.5, ease: "easeInOut", repeat: Infinity }}
+                className="relative aspect-square overflow-hidden rounded-2xl border-2 border-foreground bg-card shadow-[10px_10px_0_0_var(--foreground)]"
+              >
                 <Image
                   src={c.hero_image}
                   alt="A vibrant collection of restored Y2K digital cameras"
@@ -160,22 +141,22 @@ export function Hero({ cms = {} }: HeroProps) {
                 <span className="pointer-events-none absolute right-3 top-3 h-5 w-5 border-r-2 border-t-2 border-white/80" aria-hidden="true" />
                 <span className="pointer-events-none absolute left-3 bottom-3 h-5 w-5 border-l-2 border-b-2 border-white/80" aria-hidden="true" />
                 <span className="pointer-events-none absolute right-3 bottom-3 h-5 w-5 border-r-2 border-b-2 border-white/80" aria-hidden="true" />
-              </div>
-
-              {/* playful pills */}
-              <motion.span
-                style={{ y: yPillA }}
-                className="absolute -top-3 -left-2 sm:left-4 z-10 inline-flex items-center gap-1.5 rounded-full border-2 border-foreground bg-pop-pink px-3.5 py-1.5 font-display text-[11px] font-bold uppercase tracking-[0.1em] text-white shadow-[3px_3px_0_0_var(--foreground)]"
-              >
-                <Star className="h-3.5 w-3.5 fill-white" /> Tested &amp; Working
-              </motion.span>
-              <motion.span
-                style={{ y: yPillB }}
-                className="absolute -bottom-3 right-0 sm:right-4 z-10 inline-flex items-center gap-1.5 rounded-full border-2 border-foreground bg-pop-yellow px-3.5 py-1.5 font-display text-[11px] font-bold uppercase tracking-[0.1em] text-foreground shadow-[3px_3px_0_0_var(--foreground)]"
-              >
-                <ShieldCheck className="h-3.5 w-3.5" /> Free Returns
-              </motion.span>
+              </motion.div>
             </motion.div>
+
+            {/* playful pills */}
+            <motion.span
+              style={{ y: yPillA }}
+              className="absolute -top-3 left-3 sm:left-5 z-10 inline-flex items-center gap-1.5 rounded-full border-2 border-foreground bg-pop-pink px-3.5 py-1.5 font-display text-[11px] font-bold uppercase tracking-[0.1em] text-white shadow-[3px_3px_0_0_var(--foreground)]"
+            >
+              <Star className="h-3.5 w-3.5 fill-white" /> Tested &amp; Working
+            </motion.span>
+            <motion.span
+              style={{ y: yPillB }}
+              className="absolute -bottom-3 right-3 sm:right-5 z-10 inline-flex items-center gap-1.5 rounded-full border-2 border-foreground bg-pop-yellow px-3.5 py-1.5 font-display text-[11px] font-bold uppercase tracking-[0.1em] text-foreground shadow-[3px_3px_0_0_var(--foreground)]"
+            >
+              <ShieldCheck className="h-3.5 w-3.5" /> Free Returns
+            </motion.span>
           </motion.div>
         </div>
       </div>


### PR DESCRIPTION
- Dot pattern: faint dots only (removed dark dots + grid lines that were striking through the headline/subtitle/trust text).
- Camera card: removed the pointer 3D tilt that skewed the card into an odd parallelogram. Now a crisp rectangle with a smooth entrance + gentle idle float (no distortion); 1:1 image fits the square card exactly.
- Tightened headline scale; subtler scroll parallax on card + pills.